### PR TITLE
feat: support PHP 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,8 +21,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.4]
-        stability: [prefer-lowest, prefer-stable]
+        php: ["8.1", "8.2", "8.3", "8.4"]
+        stability: [prefer-stable]
+        include:
+          - os: ubuntu-latest
+            php: "8.1"
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -34,7 +38,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: dom, curl, libxml, mbstring, zip, openssl
           coverage: none
 
       - name: Setup problem matchers

--- a/composer.json
+++ b/composer.json
@@ -15,22 +15,24 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "guzzlehttp/guzzle": "^7.9",
-        "illuminate/support": "^12.0",
-        "illuminate/translation": "^12.0",
-        "illuminate/validation": "^12.0",
         "spatie/data-transfer-object": "^3.9"
     },
     "require-dev": {
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/translation": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/validation": "^10.0 || ^11.0 || ^12.0",
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.6",
-        "pestphp/pest": "^3.0",
+        "pestphp/pest": "^2.0 || ^3.0",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-deprecation-rules": "^2.0",
-        "spatie/ray": "^1.28",
-        "spatie/typescript-transformer": "dev-main"
+        "spatie/ray": "^1.28"
+    },
+    "suggest": {
+        "spatie/typescript-transformer": "Opcional (PHP >=8.2) para regenerar o arquivo types/generated.d.ts."
     },
     "autoload": {
         "psr-4": {

--- a/src/Support/DTO/EnumCaster.php
+++ b/src/Support/DTO/EnumCaster.php
@@ -24,7 +24,14 @@ class EnumCaster implements Caster
 
         // Handle string to int conversion for int-backed enums
         $reflection = new \ReflectionEnum($this->enumType);
-        if ($reflection->isBacked() && $reflection->getBackingType()->getName() === 'int' && is_string($value) && is_numeric($value)) {
+        $backingType = $reflection->getBackingType();
+        if (
+            $reflection->isBacked()
+            && $backingType instanceof \ReflectionNamedType
+            && $backingType->getName() === 'int'
+            && is_string($value)
+            && is_numeric($value)
+        ) {
             $value = (int) $value;
         }
 


### PR DESCRIPTION
## O que mudou
- O pacote passa a aceitar **PHP 8.1** (antes exigia 8.2+).
- Dependências `illuminate/*` foram movidas para `require-dev` e ajustadas para versões compatíveis com PHP 8.1.
- `spatie/typescript-transformer` deixou de ser dependência de desenvolvimento (exige PHP 8.2); ficou como sugestão opcional.
- CI atualizado para testar **PHP 8.1–8.4**.

## Por quê
- Ampliar compatibilidade para projetos que ainda estão em PHP 8.1, mantendo o comportamento do SDK.

## Test plan
- [ ] Rodar `composer update` (PHP 8.1)
- [ ] Rodar `vendor/bin/pest --ci`
- [ ] Rodar `vendor/bin/phpstan analyse --memory-limit 2G`
- [ ] Verificar no CI que a matriz executa em PHP 8.1–8.4