### PR TITLE
fix: #21 remover nPedRegEvento do Id do infPedReg (TSIdPedRegEvt)

### DIFF
--- a/src/Xml/EventosXmlBuilder.php
+++ b/src/Xml/EventosXmlBuilder.php
@@ -21,11 +21,11 @@ class EventosXmlBuilder
 
         $inf = $this->dom->createElement('infPedReg');
 
-        // Build Id for infPedReg: PRE + chNFSe + tipoEvento + nPedRegEvento(3 digits)
+        // Build Id for infPedReg: PRE + chNFSe + tipoEvento
+        // nPedRegEvento foi removido do Id a partir de jan/2026 (TSIdPedRegEvt: PRE[0-9]{56})
         $ch = $data->infPedReg->chaveNfse;
         $tipo = $data->infPedReg->tipoEvento;
-        $nPed = str_pad((string) $data->infPedReg->nPedRegEvento, 3, '0', STR_PAD_LEFT);
-        $id = "PRE{$ch}{$tipo}{$nPed}";
+        $id = "PRE{$ch}{$tipo}";
         $inf->setAttribute('Id', $id);
 
         $this->appendElement($inf, 'tpAmb', (string) $data->infPedReg->tipoAmbiente);

--- a/tests/Unit/Xml/EventosSigningTest.php
+++ b/tests/Unit/Xml/EventosSigningTest.php
@@ -42,7 +42,7 @@ it('builds, signs and encodes an evento payload', function () {
     $signed = $signer->sign($xml, 'infPedReg');
 
     // The signed XML should contain a Signature and a Reference to the root Id
-    $id = 'PRE'.$ch.'101101'.'003';
+    $id = 'PRE'.$ch.'101101';
     expect($signed)->toContain('Signature xmlns')
         ->and($signed)->toContain('Reference URI="#'.$id.'"');
 

--- a/tests/Unit/Xml/EventosXmlBuilderIdFormattingTest.php
+++ b/tests/Unit/Xml/EventosXmlBuilderIdFormattingTest.php
@@ -26,5 +26,5 @@ it('constructs Id with zero padded nPedRegEvento and preserves large numbers', f
     $xml = (new EventosXmlBuilder)->buildPedRegEvento($pedido);
 
     expect($xml)->toContain('nPedRegEvento>123</nPedRegEvento>');
-    expect($xml)->toContain('Id="PRE'.$ch.'101101123');
+    expect($xml)->toContain('Id="PRE'.$ch.'101101"');
 });

--- a/tests/Unit/Xml/EventosXmlBuilderOptionalTest.php
+++ b/tests/Unit/Xml/EventosXmlBuilderOptionalTest.php
@@ -24,7 +24,7 @@ it('includes CPFAutor when cpfAutor is provided and omits CNPJAutor', function (
     expect($xml)->toContain('nPedRegEvento>7</nPedRegEvento>');
     $ch = '12345678901234567890123456789012345678901234567890';
     $tipo = '101101';
-    expect($xml)->toContain('Id="PRE'.$ch.$tipo.'007');
+    expect($xml)->toContain('Id="PRE'.$ch.$tipo.'"');
 });
 
 it('does not include e101101 when no cancellation provided', function () {

--- a/tests/Unit/Xml/EventosXmlBuilderTest.php
+++ b/tests/Unit/Xml/EventosXmlBuilderTest.php
@@ -24,7 +24,7 @@ it('builds a pedRegEvento xml for cancelamento', function () {
     $xml = (new EventosXmlBuilder)->buildPedRegEvento($pedido);
 
     expect($xml)->toContain('<pedRegEvento');
-    expect($xml)->toContain('<infPedReg Id="PRE12345678901234567890123456789012345678901234567890101101');
+    expect($xml)->toContain('<infPedReg Id="PRE12345678901234567890123456789012345678901234567890101101"');
     expect($xml)->toContain('<e101101>');
     expect($xml)->toContain('<xMotivo>Teste</xMotivo>');
 });


### PR DESCRIPTION
A partir de jan/2026 o padrão TSIdPedRegEvt mudou de PRE[0-9]{59} para PRE[0-9]{56}, removendo nPedRegEvento da composição do Id. Confirmado no XSD oficial v1.01 de 2026-02-09.

Ref: #21