### PR TITLE
fix: remover elemento nPedRegEvento do XML do infPedReg

### DIFF
--- a/src/Xml/EventosXmlBuilder.php
+++ b/src/Xml/EventosXmlBuilder.php
@@ -40,9 +40,9 @@ class EventosXmlBuilder
         }
 
         $this->appendElement($inf, 'chNFSe', $data->infPedReg->chaveNfse);
-        $this->appendElement($inf, 'nPedRegEvento', (string) $data->infPedReg->nPedRegEvento);
 
-        // Only implement cancellation (e101101) for now
+        // nPedRegEvento não existe no schema XSD (nem v1.00 nem v1.01)
+        // Após chNFSe vem direto o elemento do tipo de evento (e101101, etc.)
         if ($data->infPedReg->e101101) {
             $e = $this->dom->createElement('e101101');
             $this->appendElement($e, 'xDesc', $data->infPedReg->e101101->descricao);

--- a/tests/Unit/Xml/EventosXmlBuilderIdFormattingTest.php
+++ b/tests/Unit/Xml/EventosXmlBuilderIdFormattingTest.php
@@ -5,7 +5,7 @@ use Nfse\Dto\Nfse\InfPedRegData;
 use Nfse\Dto\Nfse\PedRegEventoData;
 use Nfse\Xml\EventosXmlBuilder;
 
-it('constructs Id with zero padded nPedRegEvento and preserves large numbers', function () {
+it('constructs Id without nPedRegEvento and preserves large numbers', function () {
     $ch = str_repeat('9', 50);
     $cancel = new CancelamentoData([
         'xDesc' => 'x',
@@ -25,6 +25,7 @@ it('constructs Id with zero padded nPedRegEvento and preserves large numbers', f
     $pedido = new PedRegEventoData(['infPedReg' => $inf]);
     $xml = (new EventosXmlBuilder)->buildPedRegEvento($pedido);
 
-    expect($xml)->toContain('nPedRegEvento>123</nPedRegEvento>');
+    // nPedRegEvento não existe no schema XSD, não deve aparecer no XML
+    expect($xml)->not()->toContain('nPedRegEvento');
     expect($xml)->toContain('Id="PRE'.$ch.'101101"');
 });

--- a/tests/Unit/Xml/EventosXmlBuilderOptionalTest.php
+++ b/tests/Unit/Xml/EventosXmlBuilderOptionalTest.php
@@ -20,8 +20,8 @@ it('includes CPFAutor when cpfAutor is provided and omits CNPJAutor', function (
 
     expect($xml)->toContain('<CPFAutor>11122233344</CPFAutor>');
     expect($xml)->not()->toContain('<CNPJAutor>');
-    // Ensure nPedRegEvento is zero padded to 3 digits (007)
-    expect($xml)->toContain('nPedRegEvento>7</nPedRegEvento>');
+    // nPedRegEvento não existe no schema XSD, não deve aparecer no XML
+    expect($xml)->not()->toContain('nPedRegEvento');
     $ch = '12345678901234567890123456789012345678901234567890';
     $tipo = '101101';
     expect($xml)->toContain('Id="PRE'.$ch.$tipo.'"');


### PR DESCRIPTION
O elemento nPedRegEvento não existe no schema XSD (nem v1.00 nem v1.01). Após chNFSe o schema espera direto o tipo de evento (e101101, etc.). A presença do elemento causava erro RNG6110 (Falha Schema Xml).

Testado com cancelamento de NFSe em produção