### PR TITLE
feat: add NT 007/2026 retention helpers and update docstrings

### DIFF
--- a/src/Dto/Nfse/TributacaoData.php
+++ b/src/Dto/Nfse/TributacaoData.php
@@ -98,33 +98,56 @@ class TributacaoData extends Dto
     public ?float $aliquotaCofins = null;
 
     /**
-     * Valor PIS.
+     * Valor PIS (R$).
+     *
+     * NT 007/2026: este campo registra o valor de PIS como débito de apuração
+     * própria do prestador. Não deve ser usado para informar valores retidos.
+     * Para retenção, consolidar no campo vRetCSLL.
      */
     #[MapFrom('tribFed.piscofins.vPis')]
     public ?float $valorPis = null;
 
     /**
-     * Valor COFINS.
+     * Valor COFINS (R$).
+     *
+     * NT 007/2026: este campo registra o valor de COFINS como débito de apuração
+     * própria do prestador. Não deve ser usado para informar valores retidos.
+     * Para retenção, consolidar no campo vRetCSLL.
      */
     #[MapFrom('tribFed.piscofins.vCofins')]
     public ?float $valorCofins = null;
 
     /**
-     * Tipo de Retenção PIS/COFINS.
-     * 1 - Não Retido
-     * 2 - Retido
+     * Tipo de Retenção PIS/COFINS e CSLL.
+     *
+     * Códigos 0 e 3-9 definidos pela NT 007/2026. Atualmente o schema
+     * aceita apenas os códigos 1 e 2. Os demais serão habilitados quando
+     * os grupos IBSCBS se tornarem obrigatórios.
+     *
+     * @see TipoRetencaoPisCofins
      */
     #[MapFrom('tribFed.piscofins.tpRetPisCofins'), CastWith(EnumCaster::class, enumType: TipoRetencaoPisCofins::class)]
     public ?TipoRetencaoPisCofins $tipoRetencaoPisCofins = null;
 
     /**
-     * Valor retido de IRRF.
+     * Valor retido de IRRF (R$).
      */
     #[MapFrom('tribFed.vRetIRRF')]
     public ?float $valorRetidoIrrf = null;
 
     /**
-     * Valor retido de CSLL.
+     * Valor retido de contribuições sociais (R$).
+     *
+     * NT 007/2026: se houver retenções de PIS, COFINS e/ou CSLL, elas
+     * devem ser SOMADAS e informadas neste campo, de acordo com o tipo
+     * de retenção indicado em tpRetPisCofins.
+     *
+     * Exemplo: para tpRetPisCofins=1 (PIS/COFINS Retido) com CSLL também
+     * retida, este campo deve conter: PIS retido + COFINS retido + CSLL retida.
+     *
+     * @see TipoRetencaoPisCofins::isRetidoPis()
+     * @see TipoRetencaoPisCofins::isRetidoCofins()
+     * @see TipoRetencaoPisCofins::isRetidoCsll()
      */
     #[MapFrom('tribFed.vRetCSLL')]
     public ?float $valorRetidoCsll = null;

--- a/src/Enums/TipoRetencaoPisCofins.php
+++ b/src/Enums/TipoRetencaoPisCofins.php
@@ -77,4 +77,57 @@ enum TipoRetencaoPisCofins: int
     {
         return $this->getDescription();
     }
+
+    /**
+     * Verifica se PIS é retido neste tipo de retenção.
+     *
+     * NT 007/2026: quando retido, o valor de PIS deve ser consolidado
+     * no campo vRetCSLL da DPS.
+     */
+    public function isRetidoPis(): bool
+    {
+        return match ($this) {
+            self::PisCofinsRetido,
+            self::Retidos,
+            self::PisCofinsRetidosCsllNaoRetido,
+            self::PisRetidoCofinsCsllNaoRetido,
+            self::CofinsNaoRetidoPisCsllRetidos => true,
+            default => false,
+        };
+    }
+
+    /**
+     * Verifica se COFINS é retido neste tipo de retenção.
+     *
+     * NT 007/2026: quando retido, o valor de COFINS deve ser consolidado
+     * no campo vRetCSLL da DPS.
+     */
+    public function isRetidoCofins(): bool
+    {
+        return match ($this) {
+            self::PisCofinsRetido,
+            self::Retidos,
+            self::PisCofinsRetidosCsllNaoRetido,
+            self::CofinsRetidoPisCsllNaoRetido,
+            self::PisNaoRetidoCofinsCsllRetidos => true,
+            default => false,
+        };
+    }
+
+    /**
+     * Verifica se CSLL é retida neste tipo de retenção.
+     *
+     * NT 007/2026: quando retida, o valor de CSLL deve ser informado
+     * no campo vRetCSLL da DPS (consolidado com PIS/COFINS retidos).
+     */
+    public function isRetidoCsll(): bool
+    {
+        return match ($this) {
+            self::Retidos,
+            self::PisNaoRetidoCofinsCsllRetidos,
+            self::PisCofinsNaoRetidosCsllRetido,
+            self::CofinsNaoRetidoPisCsllRetidos => true,
+            default => false,
+        };
+    }
 }


### PR DESCRIPTION
## Contexto

A **NT SE/CGNFS-e nº 007/2026** (publicada em 07/02/2026, vigente desde 09/02/2026) esclareceu a semântica dos campos de tributação federal na DPS:

1. **`vPis` e `vCofins`** são débitos de apuração própria do prestador, **não valores retidos**
2. **`vRetCSLL`** deve consolidar PIS retido + COFINS retido + CSLL retida (somados)
3. **`tpRetPisCofins`** ganhou novos códigos (0 e 3-9), embora atualmente o schema aceite apenas 1 e 2

Ref: #26

## Alterações

### 1. Helper methods em `TipoRetencaoPisCofins`

Três novos métodos no enum para que consumidores da lib possam determinar programaticamente quais contribuições são retidas para cada código:

- `isRetidoPis()` — retorna `true` se PIS é retido
- `isRetidoCofins()` — retorna `true` se COFINS é retido  
- `isRetidoCsll()` — retorna `true` se CSLL é retida

Exemplo de uso para calcular `vRetCSLL` consolidado:

```php
$tipo = TipoRetencaoPisCofins::PisCofinsRetido; // código 1

$vRetCSLL = 0;
if ($tipo->isRetidoPis()) {
    $vRetCSLL += $valorPisRetido;
}
if ($tipo->isRetidoCofins()) {
    $vRetCSLL += $valorCofinsRetido;
}
if ($tipo->isRetidoCsll()) {
    $vRetCSLL += $valorCsllRetida;
}
```

### 2. Docstrings atualizadas em `TributacaoData`

- `valorPis` / `valorCofins`: esclarecido que são débitos de apuração própria
- `valorRetidoCsll`: documentado que deve consolidar PIS+COFINS+CSLL retidos
- `tipoRetencaoPisCofins`: nota sobre códigos 0 e 3-9 definidos mas ainda não no schema

## Referência

- [NT SE/CGNFS-e nº 007/2026 (PDF)](https://www.gov.br/nfse/pt-br/biblioteca/documentacao-tecnica/rtc/nt-007-se-cgnfse-v1-0.pdf/view)
- Seção 2c) PIS/COFINS, página 6: _"Se houver valores de retenções de PIS, de COFINS e/ou de CSLL, eles deverão ser SOMADOS e informados no campo 'vRetCSLL'"_