### PR TITLE
Em meus teste em produção só tive exito no cancalemtno após adicionar…

### DIFF
--- a/examples/contribuinte/cancelar.php
+++ b/examples/contribuinte/cancelar.php
@@ -34,6 +34,8 @@ try {
             'cnpjAutor' => $cnpjAutor,
             'tipoEvento' => '101101', // Código para Cancelamento
             'e101101' => [
+                // XSD v1.01 (TE101101): valor fixo enumerado para xDesc.
+                'xDesc' => 'Cancelamento de NFS-e',
                 'cMotivo' => '1', // 1 - Erro na emissão
                 'xMotivo' => 'Teste de cancelamento via SDK PHP',
             ],
@@ -43,9 +45,9 @@ try {
     echo "Cancelando NFS-e: $chaveNfse...\n";
 
     /**
-     * Você pode usar o método direto (se disponível no Service) 
+     * Você pode usar o método direto (se disponível no Service)
      * ou montar o processo manualmente caso a versão do SDK seja anterior.
-     * 
+     *
      * Neste exemplo, demonstramos como seria a chamada simplificada:
      */
     $response = $nfse->contribuinte()->cancelar($eventoData);


### PR DESCRIPTION
Estava realizando os teste de cancelamento seguindo o exemplo e estava me retornarno um erro que preciasa do 

xDesc como mostra no schema:
<xs:element name="xDesc">
  <xs:annotation>
    <xs:documentation>
      Descrição do Evento: Descrição do evento: "Cancelamento de NFS-e".
    </xs:documentation>
  </xs:annotation>
  <xs:simpleType>
    <xs:restriction base="xs:string">
      <xs:whiteSpace value="preserve"/>
      <xs:enumeration value="Cancelamento de NFS-e"/>
      
Fiz a correção no exemplo e o cancalmento foi realizado corretamente.
    
Estava recebendo o seguinte erro: "The 'http://www.sped.fazenda.gov.br/nfse:xDesc' element is invalid - The value '9' is invalid according to its datatype 'String' - The Enumeration constraint failed."

até mais!