### PR TITLE
feat: implementa o grupo IBS/CBS na DPS e na NFS-e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to `nfse-php` will be documented in this file.
 
+## [Unreleased]
+
+### 🧾 Grupo IBS/CBS (Reforma Tributária sobre o Consumo)
+
+Implementação do grupo `IBSCBS` conforme o pacote de esquemas AnexoVI v1.01.03 (NT 004),
+nos dois sentidos: informações declaradas na DPS e valores calculados pelo Sistema Nacional
+na NFS-e.
+
+### ✨ Funcionalidades
+
+-   `IbscbsData` passa a cobrir o grupo declarado na DPS: `finNFSe`, `indFinal`, `cIndOp`,
+    `tpOper`, `gRefNFSe`, `tpEnteGov`, `indDest`, `dest`, `imovel`, `gReeRepRes` e
+    `gIBSCBS` (CST, cClassTrib, cCredPres, gTribRegular e gDif).
+-   `IbscbsNfseData` expõe o grupo calculado retornado na NFS-e, incluindo alíquotas
+    efetivas, totalizadores de IBS e CBS, crédito presumido, tributação regular e
+    compras governamentais.
+-   Novos DTOs `ImovelData` e `ReembolsoDocumentoData`.
+-   Novos enums `TipoOperacaoRtc`, `TipoEnteGovernamental`, `IndicadorDestinatario`,
+    `TipoChaveDFe` e `TipoReembolsoRepasseRessarcimento`.
+-   `DpsValidator` valida as regras de negócio do grupo que não dependem de tabelas
+    externas (RN 324, 542, 549, 554, 618/619, 621, 622 e 627).
+-   Novo exemplo `examples/contribuinte/emitir_ibscbs.php`.
+
+### 🐛 Correções
+
+-   `cLocEmi` passa a ser serializado depois de `cMotivoEmisTI` e `chNFSeRej`, como exige
+    a sequência do XSD. A ordem anterior invalidava a DPS quando esses campos eram usados.
+-   Grupos repetíveis com uma única ocorrência deixam de ser desmontados na leitura do XML
+    (`ArrayCaster`), o que também corrige `vDedRed/documentos`.
+
+### ⚠️ Breaking changes
+
+-   Removido `IbscbsData::$indicadorZfmAlc` e a emissão do elemento `indZFMALC`. O campo
+    não existe no esquema oficial nem no Anexo I e gerava XML rejeitado.
+
 ## [1.4.0-beta] - 2026-01-06
 
 ### 🎯 Type Safety com Enums

--- a/examples/contribuinte/emitir.php
+++ b/examples/contribuinte/emitir.php
@@ -35,7 +35,7 @@ try {
 
     $dps = new DpsData([
         '@attributes' => [
-            'versao' => '1.00',
+            'versao' => '1.01',
         ],
         'infDPS' => [
             '@attributes' => [

--- a/examples/contribuinte/emitir_com_certificado_em_memoria.php
+++ b/examples/contribuinte/emitir_com_certificado_em_memoria.php
@@ -43,7 +43,7 @@ try {
     );
 
     $dps = new DpsData([
-        '@attributes' => ['versao' => '1.00'],
+        '@attributes' => ['versao' => '1.01'],
         'infDPS' => [
             '@attributes' => ['Id' => $idDps],
             'tpAmb'    => 2,

--- a/examples/contribuinte/emitir_ibscbs.php
+++ b/examples/contribuinte/emitir_ibscbs.php
@@ -35,7 +35,7 @@ try {
 
     $dps = new DpsData([
         '@attributes' => [
-            'versao' => '1.00',
+            'versao' => '1.01',
         ],
         'infDPS' => [
             '@attributes' => [

--- a/examples/contribuinte/emitir_ibscbs.php
+++ b/examples/contribuinte/emitir_ibscbs.php
@@ -1,0 +1,134 @@
+<?php
+
+use Nfse\Dto\Nfse\DpsData;
+use Nfse\Http\NfseContext;
+use Nfse\Nfse;
+use Nfse\Support\IdGenerator;
+
+/** @var \Nfse\Nfse $nfse */
+$nfse = require_once __DIR__.'/../bootstrap.php';
+
+try {
+    // $certificatePath = __DIR__.'/certs/cert.pfx';
+    // $certificatePassword = 'senha';
+
+    $context = new NfseContext(
+        ambiente: \Nfse\Enums\TipoAmbiente::Homologacao,
+        certificatePath: $certificatePath,
+        certificatePassword: $certificatePassword
+    );
+
+    $nfse = new Nfse($context);
+
+    date_default_timezone_set('America/Sao_Paulo');
+    $cnpjPrestador = '03279735000194';
+    $codigoMunicipio = '2304400';
+    $serie = '1';
+    $numero = '100';
+
+    $idDps = IdGenerator::generateDpsId(
+        cpfCnpj: $cnpjPrestador,
+        codIbge: $codigoMunicipio,
+        serieDps: $serie,
+        numDps: $numero
+    );
+
+    $dps = new DpsData([
+        '@attributes' => [
+            'versao' => '1.00',
+        ],
+        'infDPS' => [
+            '@attributes' => [
+                'Id' => $idDps,
+            ],
+            'tpAmb' => 2, // Homologação
+            'dhEmi' => date('c'),
+            'verAplic' => 'SDK-PHP-1.0',
+            'serie' => $serie,
+            'nDPS' => $numero,
+            'dCompet' => date('Y-m-d'), // O grupo IBSCBS só é aceito a partir de 01/01/2026
+            'tpEmit' => 1, // Prestador
+            'cLocEmi' => $codigoMunicipio,
+
+            'prest' => [
+                'CNPJ' => $cnpjPrestador,
+                'xNome' => 'Empresa de Teste',
+                'end' => [
+                    'endNac' => [
+                        'cMun' => $codigoMunicipio,
+                        'CEP' => '60000000',
+                    ],
+                    'xLgr' => 'Rua Teste',
+                    'nro' => '123',
+                    'xBairro' => 'Centro',
+                ],
+                'regTrib' => [
+                    'opSimpNac' => 1, // Não Optante
+                    'regEspTrib' => 0, // Nenhum
+                ],
+            ],
+            'toma' => [
+                'CNPJ' => '44827692000111',
+                'xNome' => 'Cliente de Teste',
+            ],
+            'serv' => [
+                'locPrest' => [
+                    'cLocPrestacao' => $codigoMunicipio,
+                ],
+                'cServ' => [
+                    'cTribNac' => '010101',
+                    'xDescServ' => 'Desenvolvimento de Software',
+                    // O item da NBS é obrigatório quando o grupo IBSCBS é informado
+                    'cNBS' => '112011000',
+                ],
+            ],
+            'valores' => [
+                'vServPrest' => [
+                    'vServ' => 100.00,
+                ],
+                'trib' => [
+                    'tribMun' => [
+                        'tribISSQN' => 1,
+                        'tpRetISSQN' => 1,
+                    ],
+                    'totTrib' => [
+                        'indTotTrib' => 0,
+                    ],
+                ],
+            ],
+            'IBSCBS' => [
+                'finNFSe' => '0', // NFS-e regular
+                'cIndOp' => '010101', // Código indicador da operação (Anexo VII)
+                'indDest' => 0, // O destinatário é o próprio tomador
+                'valores' => [
+                    'trib' => [
+                        'gIBSCBS' => [
+                            'CST' => '000', // Tributação integral
+                            'cClassTrib' => '000001',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    echo "Emitindo NFS-e com IBS/CBS para a DPS: $idDps...\n";
+
+    $nfseData = $nfse->contribuinte()->emitir($dps);
+
+    echo "NFS-e emitida com sucesso!\n";
+    echo 'Chave de Acesso: '.$nfseData->infNfse->id."\n";
+
+    $ibscbs = $nfseData->infNfse->ibscbs;
+
+    if ($ibscbs) {
+        echo 'Localidade de incidência: '.$ibscbs->nomeLocalidadeIncidencia."\n";
+        echo 'Base de cálculo IBS/CBS: '.$ibscbs->baseCalculo."\n";
+        echo 'IBS total: '.$ibscbs->valorTotalIbs."\n";
+        echo 'CBS: '.$ibscbs->valorCbs."\n";
+        echo 'Valor total da nota com os tributos por fora: '.$ibscbs->valorTotalNota."\n";
+    }
+
+} catch (\Exception $e) {
+    echo 'Erro: '.$e->getMessage()."\n";
+}

--- a/src/Dto/Nfse/IbscbsData.php
+++ b/src/Dto/Nfse/IbscbsData.php
@@ -3,15 +3,131 @@
 namespace Nfse\Dto\Nfse;
 
 use Nfse\Dto\Dto;
+use Nfse\Enums\IndicadorDestinatario;
+use Nfse\Enums\TipoEnteGovernamental;
+use Nfse\Enums\TipoOperacaoRtc;
+use Nfse\Support\DTO\ArrayCaster;
+use Nfse\Support\DTO\EnumCaster;
+use Spatie\DataTransferObject\Attributes\CastWith;
 use Spatie\DataTransferObject\Attributes\MapFrom;
 
 class IbscbsData extends Dto
 {
     /**
-     * Indicador da operação de fornecimento favorecido com alíquota zero de CBS.
+     * Indicador da finalidade da emissão de NFS-e.
+     * 0 - NFS-e regular
+     */
+    #[MapFrom('finNFSe')]
+    public ?string $finalidadeNfse = null;
+
+    /**
+     * Indica operação de uso ou consumo pessoal (art. 57).
      * 0 - Não
      * 1 - Sim
      */
-    #[MapFrom('indZFMALC')]
-    public ?int $indicadorZfmAlc = null;
+    #[MapFrom('indFinal')]
+    public ?int $indicadorUsoConsumoPessoal = null;
+
+    /**
+     * Código indicador da operação de fornecimento, conforme tabela
+     * "código indicador de operação" (Anexo VII).
+     */
+    #[MapFrom('cIndOp')]
+    public ?string $codigoIndicadorOperacao = null;
+
+    /**
+     * Tipo de Operação com Entes Governamentais ou outros serviços sobre bens imóveis.
+     */
+    #[MapFrom('tpOper'), CastWith(EnumCaster::class, enumType: TipoOperacaoRtc::class)]
+    public ?TipoOperacaoRtc $tipoOperacao = null;
+
+    /**
+     * Chaves de acesso das NFS-e referenciadas.
+     *
+     * @var string[]|null
+     */
+    #[MapFrom('gRefNFSe.refNFSe')]
+    public ?array $chavesNfseReferenciadas = null;
+
+    /**
+     * Tipo de ente governamental.
+     * Informado apenas no caso de compras governamentais.
+     */
+    #[MapFrom('tpEnteGov'), CastWith(EnumCaster::class, enumType: TipoEnteGovernamental::class)]
+    public ?TipoEnteGovernamental $tipoEnteGovernamental = null;
+
+    /**
+     * A respeito do destinatário dos serviços.
+     */
+    #[MapFrom('indDest'), CastWith(EnumCaster::class, enumType: IndicadorDestinatario::class)]
+    public ?IndicadorDestinatario $indicadorDestinatario = null;
+
+    /**
+     * Dados do destinatário do serviço.
+     * Só deve ser identificado quando indDest = 1.
+     */
+    #[MapFrom('dest')]
+    public ?TomadorData $destinatario = null;
+
+    /**
+     * Informações de operações relacionadas a bens imóveis, exceto obras.
+     */
+    #[MapFrom('imovel')]
+    public ?ImovelData $imovel = null;
+
+    /**
+     * Documentos referenciados de reembolso, repasse ou ressarcimento.
+     *
+     * @var ReembolsoDocumentoData[]|null
+     */
+    #[MapFrom('valores.gReeRepRes.documentos'), CastWith(ArrayCaster::class, itemType: ReembolsoDocumentoData::class)]
+    public ?array $documentosReembolso = null;
+
+    /**
+     * Código de Situação Tributária do IBS e da CBS.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.CST')]
+    public ?string $cst = null;
+
+    /**
+     * Código de Classificação Tributária do IBS e da CBS.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.cClassTrib')]
+    public ?string $codigoClassificacaoTributaria = null;
+
+    /**
+     * Código e classificação do crédito presumido do IBS e da CBS.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.cCredPres')]
+    public ?string $codigoCreditoPresumido = null;
+
+    /**
+     * Código de Situação Tributária do IBS e da CBS de tributação regular.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.gTribRegular.CSTReg')]
+    public ?string $cstTributacaoRegular = null;
+
+    /**
+     * Código da Classificação Tributária do IBS e da CBS de tributação regular.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.gTribRegular.cClassTribReg')]
+    public ?string $codigoClassificacaoTributariaRegular = null;
+
+    /**
+     * Percentual de diferimento para o IBS estadual.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.gDif.pDifUF')]
+    public ?float $percentualDiferimentoUf = null;
+
+    /**
+     * Percentual de diferimento para o IBS municipal.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.gDif.pDifMun')]
+    public ?float $percentualDiferimentoMunicipal = null;
+
+    /**
+     * Percentual de diferimento para a CBS.
+     */
+    #[MapFrom('valores.trib.gIBSCBS.gDif.pDifCBS')]
+    public ?float $percentualDiferimentoCbs = null;
 }

--- a/src/Dto/Nfse/IbscbsNfseData.php
+++ b/src/Dto/Nfse/IbscbsNfseData.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Nfse\Dto\Nfse;
+
+use Nfse\Dto\Dto;
+use Spatie\DataTransferObject\Attributes\MapFrom;
+
+class IbscbsNfseData extends Dto
+{
+    /**
+     * Código IBGE da localidade de incidência do IBS/CBS (local da operação).
+     */
+    #[MapFrom('cLocalidadeIncid')]
+    public ?string $codigoLocalidadeIncidencia = null;
+
+    /**
+     * Nome da localidade de incidência do IBS/CBS.
+     */
+    #[MapFrom('xLocalidadeIncid')]
+    public ?string $nomeLocalidadeIncidencia = null;
+
+    /**
+     * Percentual de redução de alíquota em compra governamental.
+     */
+    #[MapFrom('pRedutor')]
+    public ?float $percentualRedutor = null;
+
+    /**
+     * Valor da base de cálculo do IBS/CBS antes das reduções.
+     */
+    #[MapFrom('valores.vBC')]
+    public ?float $baseCalculo = null;
+
+    /**
+     * Valor total relativo a reembolso, repasse ou ressarcimento que não integra
+     * a base de cálculo do ISSQN, do IBS e da CBS.
+     */
+    #[MapFrom('valores.vCalcReeRepRes')]
+    public ?float $valorCalculadoReembolso = null;
+
+    /**
+     * Alíquota da UF para IBS da localidade de incidência.
+     */
+    #[MapFrom('valores.uf.pIBSUF')]
+    public ?float $aliquotaIbsUf = null;
+
+    /**
+     * Percentual de redução de alíquota estadual.
+     */
+    #[MapFrom('valores.uf.pRedAliqUF')]
+    public ?float $percentualReducaoAliquotaUf = null;
+
+    /**
+     * Alíquota efetiva da UF para IBS.
+     */
+    #[MapFrom('valores.uf.pAliqEfetUF')]
+    public ?float $aliquotaEfetivaUf = null;
+
+    /**
+     * Alíquota do Município para IBS da localidade de incidência.
+     */
+    #[MapFrom('valores.mun.pIBSMun')]
+    public ?float $aliquotaIbsMunicipal = null;
+
+    /**
+     * Percentual de redução de alíquota municipal.
+     */
+    #[MapFrom('valores.mun.pRedAliqMun')]
+    public ?float $percentualReducaoAliquotaMunicipal = null;
+
+    /**
+     * Alíquota efetiva do Município para IBS.
+     */
+    #[MapFrom('valores.mun.pAliqEfetMun')]
+    public ?float $aliquotaEfetivaMunicipal = null;
+
+    /**
+     * Alíquota da União para CBS.
+     */
+    #[MapFrom('valores.fed.pCBS')]
+    public ?float $aliquotaCbs = null;
+
+    /**
+     * Percentual de redução de alíquota da CBS.
+     */
+    #[MapFrom('valores.fed.pRedAliqCBS')]
+    public ?float $percentualReducaoAliquotaCbs = null;
+
+    /**
+     * Alíquota efetiva da União para CBS.
+     */
+    #[MapFrom('valores.fed.pAliqEfetCBS')]
+    public ?float $aliquotaEfetivaCbs = null;
+
+    /**
+     * Valor total da NFS-e considerando os impostos por fora (IBS e CBS).
+     */
+    #[MapFrom('totCIBS.vTotNF')]
+    public ?float $valorTotalNota = null;
+
+    /**
+     * Valor total do IBS.
+     */
+    #[MapFrom('totCIBS.gIBS.vIBSTot')]
+    public ?float $valorTotalIbs = null;
+
+    /**
+     * Alíquota do crédito presumido para o IBS.
+     */
+    #[MapFrom('totCIBS.gIBS.gIBSCredPres.pCredPresIBS')]
+    public ?float $aliquotaCreditoPresumidoIbs = null;
+
+    /**
+     * Valor do crédito presumido para o IBS.
+     */
+    #[MapFrom('totCIBS.gIBS.gIBSCredPres.vCredPresIBS')]
+    public ?float $valorCreditoPresumidoIbs = null;
+
+    /**
+     * Total do diferimento do IBS estadual.
+     */
+    #[MapFrom('totCIBS.gIBS.gIBSUFTot.vDifUF')]
+    public ?float $valorDiferimentoUf = null;
+
+    /**
+     * Total do valor do IBS estadual.
+     */
+    #[MapFrom('totCIBS.gIBS.gIBSUFTot.vIBSUF')]
+    public ?float $valorIbsUf = null;
+
+    /**
+     * Total do diferimento do IBS municipal.
+     */
+    #[MapFrom('totCIBS.gIBS.gIBSMunTot.vDifMun')]
+    public ?float $valorDiferimentoMunicipal = null;
+
+    /**
+     * Total do valor do IBS municipal.
+     */
+    #[MapFrom('totCIBS.gIBS.gIBSMunTot.vIBSMun')]
+    public ?float $valorIbsMunicipal = null;
+
+    /**
+     * Alíquota do crédito presumido para a CBS.
+     */
+    #[MapFrom('totCIBS.gCBS.gCBSCredPres.pCredPresCBS')]
+    public ?float $aliquotaCreditoPresumidoCbs = null;
+
+    /**
+     * Valor do crédito presumido da CBS.
+     */
+    #[MapFrom('totCIBS.gCBS.gCBSCredPres.vCredPresCBS')]
+    public ?float $valorCreditoPresumidoCbs = null;
+
+    /**
+     * Total do diferimento da CBS.
+     */
+    #[MapFrom('totCIBS.gCBS.vDifCBS')]
+    public ?float $valorDiferimentoCbs = null;
+
+    /**
+     * Total do valor da CBS da União.
+     */
+    #[MapFrom('totCIBS.gCBS.vCBS')]
+    public ?float $valorCbs = null;
+
+    /**
+     * Alíquota efetiva de tributação regular do IBS estadual.
+     */
+    #[MapFrom('totCIBS.gTribRegular.pAliqEfeRegIBSUF')]
+    public ?float $aliquotaEfetivaRegularIbsUf = null;
+
+    /**
+     * Valor da tributação regular do IBS estadual.
+     */
+    #[MapFrom('totCIBS.gTribRegular.vTribRegIBSUF')]
+    public ?float $valorTributacaoRegularIbsUf = null;
+
+    /**
+     * Alíquota efetiva de tributação regular do IBS municipal.
+     */
+    #[MapFrom('totCIBS.gTribRegular.pAliqEfeRegIBSMun')]
+    public ?float $aliquotaEfetivaRegularIbsMunicipal = null;
+
+    /**
+     * Valor da tributação regular do IBS municipal.
+     */
+    #[MapFrom('totCIBS.gTribRegular.vTribRegIBSMun')]
+    public ?float $valorTributacaoRegularIbsMunicipal = null;
+
+    /**
+     * Alíquota efetiva de tributação regular da CBS.
+     */
+    #[MapFrom('totCIBS.gTribRegular.pAliqEfeRegCBS')]
+    public ?float $aliquotaEfetivaRegularCbs = null;
+
+    /**
+     * Valor da tributação regular da CBS.
+     */
+    #[MapFrom('totCIBS.gTribRegular.vTribRegCBS')]
+    public ?float $valorTributacaoRegularCbs = null;
+
+    /**
+     * Alíquota do IBS de competência do Estado em compras governamentais.
+     */
+    #[MapFrom('totCIBS.gTribCompraGov.pIBSUF')]
+    public ?float $aliquotaCompraGovIbsUf = null;
+
+    /**
+     * Valor do tributo do IBS da UF calculado em compras governamentais.
+     */
+    #[MapFrom('totCIBS.gTribCompraGov.vIBSUF')]
+    public ?float $valorCompraGovIbsUf = null;
+
+    /**
+     * Alíquota do IBS de competência do Município em compras governamentais.
+     */
+    #[MapFrom('totCIBS.gTribCompraGov.pIBSMun')]
+    public ?float $aliquotaCompraGovIbsMunicipal = null;
+
+    /**
+     * Valor do tributo do IBS do Município calculado em compras governamentais.
+     */
+    #[MapFrom('totCIBS.gTribCompraGov.vIBSMun')]
+    public ?float $valorCompraGovIbsMunicipal = null;
+
+    /**
+     * Alíquota da CBS em compras governamentais.
+     */
+    #[MapFrom('totCIBS.gTribCompraGov.pCBS')]
+    public ?float $aliquotaCompraGovCbs = null;
+
+    /**
+     * Valor do tributo da CBS calculado em compras governamentais.
+     */
+    #[MapFrom('totCIBS.gTribCompraGov.vCBS')]
+    public ?float $valorCompraGovCbs = null;
+}

--- a/src/Dto/Nfse/ImovelData.php
+++ b/src/Dto/Nfse/ImovelData.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Nfse\Dto\Nfse;
+
+use Nfse\Dto\Dto;
+use Spatie\DataTransferObject\Attributes\MapFrom;
+
+class ImovelData extends Dto
+{
+    /**
+     * Inscrição imobiliária fiscal fornecida pela Prefeitura Municipal.
+     */
+    #[MapFrom('inscImobFisc')]
+    public ?string $inscricaoImobiliariaFiscal = null;
+
+    /**
+     * Código do Cadastro Imobiliário Brasileiro (CIB).
+     */
+    #[MapFrom('cCIB')]
+    public ?string $codigoCib = null;
+
+    /**
+     * Endereço do imóvel.
+     */
+    #[MapFrom('end')]
+    public ?EnderecoData $endereco = null;
+}

--- a/src/Dto/Nfse/InfNfseData.php
+++ b/src/Dto/Nfse/InfNfseData.php
@@ -137,4 +137,10 @@ class InfNfseData extends Dto
      */
     #[MapFrom('valores')]
     public ?ValoresNfseData $valores = null;
+
+    /**
+     * Grupo de informações geradas pelo sistema referentes ao IBS e à CBS.
+     */
+    #[MapFrom('IBSCBS')]
+    public ?IbscbsNfseData $ibscbs = null;
 }

--- a/src/Dto/Nfse/ReembolsoDocumentoData.php
+++ b/src/Dto/Nfse/ReembolsoDocumentoData.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Nfse\Dto\Nfse;
+
+use Nfse\Dto\Dto;
+use Nfse\Enums\TipoChaveDFe;
+use Nfse\Enums\TipoReembolsoRepasseRessarcimento;
+use Nfse\Support\DTO\EnumCaster;
+use Spatie\DataTransferObject\Attributes\CastWith;
+use Spatie\DataTransferObject\Attributes\MapFrom;
+
+class ReembolsoDocumentoData extends Dto
+{
+    /**
+     * Documento fiscal a que se refere a chave de DF-e do Repositório Nacional.
+     */
+    #[MapFrom('dFeNacional.tipoChaveDFe'), CastWith(EnumCaster::class, enumType: TipoChaveDFe::class)]
+    public ?TipoChaveDFe $tipoChaveDfe = null;
+
+    /**
+     * Descrição do DF-e a que se refere a chave.
+     * Preenchido apenas quando tipoChaveDFe = 9.
+     */
+    #[MapFrom('dFeNacional.xTipoChaveDFe')]
+    public ?string $descricaoTipoChaveDfe = null;
+
+    /**
+     * Chave do Documento Fiscal eletrônico do repositório nacional.
+     */
+    #[MapFrom('dFeNacional.chaveDFe')]
+    public ?string $chaveDfe = null;
+
+    /**
+     * Código do município emissor do documento fiscal que não se encontra
+     * no repositório nacional.
+     */
+    #[MapFrom('docFiscalOutro.cMunDocFiscal')]
+    public ?string $codigoMunicipioDocumentoFiscal = null;
+
+    /**
+     * Número do documento fiscal que não se encontra no repositório nacional.
+     */
+    #[MapFrom('docFiscalOutro.nDocFiscal')]
+    public ?string $numeroDocumentoFiscal = null;
+
+    /**
+     * Descrição do documento fiscal.
+     */
+    #[MapFrom('docFiscalOutro.xDocFiscal')]
+    public ?string $descricaoDocumentoFiscal = null;
+
+    /**
+     * Número do documento não fiscal.
+     */
+    #[MapFrom('docOutro.nDoc')]
+    public ?string $numeroDocumento = null;
+
+    /**
+     * Descrição do documento não fiscal.
+     */
+    #[MapFrom('docOutro.xDoc')]
+    public ?string $descricaoDocumento = null;
+
+    /**
+     * Fornecedor do documento referenciado.
+     */
+    #[MapFrom('fornec')]
+    public ?FornecedorData $fornecedor = null;
+
+    /**
+     * Data da emissão do documento.
+     * Formato: AAAA-MM-DD
+     */
+    #[MapFrom('dtEmiDoc')]
+    public ?string $dataEmissaoDocumento = null;
+
+    /**
+     * Data da competência do documento.
+     * Formato: AAAA-MM-DD
+     */
+    #[MapFrom('dtCompDoc')]
+    public ?string $dataCompetenciaDocumento = null;
+
+    /**
+     * Tipo de reembolso, repasse ou ressarcimento.
+     */
+    #[MapFrom('tpReeRepRes'), CastWith(EnumCaster::class, enumType: TipoReembolsoRepasseRessarcimento::class)]
+    public ?TipoReembolsoRepasseRessarcimento $tipoReembolso = null;
+
+    /**
+     * Descrição do reembolso ou ressarcimento.
+     * Só deve ser informada quando tpReeRepRes = 99.
+     */
+    #[MapFrom('xTpReeRepRes')]
+    public ?string $descricaoTipoReembolso = null;
+
+    /**
+     * Valor monetário utilizado para não inclusão na base de cálculo do ISSQN,
+     * do IBS e da CBS da NFS-e que está sendo emitida (R$).
+     */
+    #[MapFrom('vlrReeRepRes')]
+    public ?float $valorReembolso = null;
+}

--- a/src/Enums/IndicadorDestinatario.php
+++ b/src/Enums/IndicadorDestinatario.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Nfse\Enums;
+
+/**
+ * Indicador a respeito do destinatário dos serviços
+ */
+enum IndicadorDestinatario: int
+{
+    /**
+     * O destinatário é o próprio tomador/adquirente identificado na NFS-e
+     * (tomador = adquirente = destinatário)
+     */
+    case DestinatarioTomador = 0;
+
+    /**
+     * O destinatário não é o próprio adquirente, podendo ser outra pessoa, física ou
+     * jurídica (ou equiparada), ou um estabelecimento diferente do indicado como tomador
+     * (tomador = adquirente ≠ destinatário)
+     */
+    case DestinatarioDiverso = 1;
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::DestinatarioTomador => 'O destinatário é o próprio tomador/adquirente',
+            self::DestinatarioDiverso => 'O destinatário não é o próprio adquirente',
+        };
+    }
+
+    public function label(): string
+    {
+        return $this->getDescription();
+    }
+}

--- a/src/Enums/TipoChaveDFe.php
+++ b/src/Enums/TipoChaveDFe.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Nfse\Enums;
+
+/**
+ * Documento fiscal a que se refere a chave de DF-e do Repositório Nacional
+ */
+enum TipoChaveDFe: int
+{
+    /**
+     * NFS-e
+     */
+    case Nfse = 1;
+
+    /**
+     * NF-e
+     */
+    case Nfe = 2;
+
+    /**
+     * CT-e
+     */
+    case Cte = 3;
+
+    /**
+     * Outro
+     */
+    case Outro = 9;
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Nfse => 'NFS-e',
+            self::Nfe => 'NF-e',
+            self::Cte => 'CT-e',
+            self::Outro => 'Outro',
+        };
+    }
+
+    public function label(): string
+    {
+        return $this->getDescription();
+    }
+}

--- a/src/Enums/TipoEnteGovernamental.php
+++ b/src/Enums/TipoEnteGovernamental.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Nfse\Enums;
+
+/**
+ * Tipo de ente governamental, para administração pública direta e suas autarquias e fundações
+ */
+enum TipoEnteGovernamental: int
+{
+    /**
+     * União
+     */
+    case Uniao = 1;
+
+    /**
+     * Estado
+     */
+    case Estado = 2;
+
+    /**
+     * Distrito Federal
+     */
+    case DistritoFederal = 3;
+
+    /**
+     * Município
+     */
+    case Municipio = 4;
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::Uniao => 'União',
+            self::Estado => 'Estado',
+            self::DistritoFederal => 'Distrito Federal',
+            self::Municipio => 'Município',
+        };
+    }
+
+    public function label(): string
+    {
+        return $this->getDescription();
+    }
+}

--- a/src/Enums/TipoOperacaoRtc.php
+++ b/src/Enums/TipoOperacaoRtc.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Nfse\Enums;
+
+/**
+ * Tipo de Operação com Entes Governamentais ou outros serviços sobre bens imóveis
+ */
+enum TipoOperacaoRtc: int
+{
+    /**
+     * Fornecimento com pagamento posterior
+     */
+    case FornecimentoPagamentoPosterior = 1;
+
+    /**
+     * Recebimento do pagamento com fornecimento já realizado
+     */
+    case RecebimentoFornecimentoRealizado = 2;
+
+    /**
+     * Fornecimento com pagamento já realizado
+     */
+    case FornecimentoPagamentoRealizado = 3;
+
+    /**
+     * Recebimento do pagamento com fornecimento posterior
+     */
+    case RecebimentoFornecimentoPosterior = 4;
+
+    /**
+     * Fornecimento e recebimento do pagamento concomitantes
+     */
+    case FornecimentoRecebimentoConcomitantes = 5;
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::FornecimentoPagamentoPosterior => 'Fornecimento com pagamento posterior',
+            self::RecebimentoFornecimentoRealizado => 'Recebimento do pagamento com fornecimento já realizado',
+            self::FornecimentoPagamentoRealizado => 'Fornecimento com pagamento já realizado',
+            self::RecebimentoFornecimentoPosterior => 'Recebimento do pagamento com fornecimento posterior',
+            self::FornecimentoRecebimentoConcomitantes => 'Fornecimento e recebimento do pagamento concomitantes',
+        };
+    }
+
+    public function label(): string
+    {
+        return $this->getDescription();
+    }
+
+    /**
+     * Indica se o tipo de operação exige o grupo de NFS-e referenciadas.
+     */
+    public function exigeNfseReferenciada(): bool
+    {
+        return in_array($this, [self::RecebimentoFornecimentoRealizado, self::FornecimentoPagamentoRealizado], true);
+    }
+}

--- a/src/Enums/TipoReembolsoRepasseRessarcimento.php
+++ b/src/Enums/TipoReembolsoRepasseRessarcimento.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Nfse\Enums;
+
+/**
+ * Tipo de valor incluído no documento, recebido por estar relacionado a operações de
+ * terceiros, objeto de reembolso, repasse ou ressarcimento pelo recebedor, já tributados
+ */
+enum TipoReembolsoRepasseRessarcimento: string
+{
+    /**
+     * Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação
+     */
+    case IntermediacaoImoveis = '01';
+
+    /**
+     * Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo
+     */
+    case AgenciaTurismo = '02';
+
+    /**
+     * Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por
+     * valores pagos relativos a serviços de produção externa por conta e ordem de terceiro
+     */
+    case ProducaoExterna = '03';
+
+    /**
+     * Reembolso ou ressarcimento recebido por agência de propaganda e publicidade por
+     * valores pagos relativos a serviços de mídia por conta e ordem de terceiro
+     */
+    case Midia = '04';
+
+    /**
+     * Outros reembolsos ou ressarcimentos recebidos por valores pagos relativos a
+     * operações por conta e ordem de terceiro
+     */
+    case Outros = '99';
+
+    public function getDescription(): string
+    {
+        return match ($this) {
+            self::IntermediacaoImoveis => 'Repasse de remuneração por intermediação de imóveis a demais corretores envolvidos na operação',
+            self::AgenciaTurismo => 'Repasse de valores a fornecedor relativo a fornecimento intermediado por agência de turismo',
+            self::ProducaoExterna => 'Reembolso ou ressarcimento por serviços de produção externa por conta e ordem de terceiro',
+            self::Midia => 'Reembolso ou ressarcimento por serviços de mídia por conta e ordem de terceiro',
+            self::Outros => 'Outros reembolsos ou ressarcimentos por operações por conta e ordem de terceiro',
+        };
+    }
+
+    public function label(): string
+    {
+        return $this->getDescription();
+    }
+}

--- a/src/Support/DTO/ArrayCaster.php
+++ b/src/Support/DTO/ArrayCaster.php
@@ -18,6 +18,11 @@ class ArrayCaster implements Caster
             return $value;
         }
 
+        // Grupos com ocorrência única chegam do XML como array associativo
+        if (! array_is_list($value)) {
+            $value = [$value];
+        }
+
         return array_map(
             function ($data) {
                 if (is_array($data)) {

--- a/src/Validator/DpsValidator.php
+++ b/src/Validator/DpsValidator.php
@@ -5,6 +5,8 @@ namespace Nfse\Validator;
 use Nfse\Dto\Nfse\DpsData;
 use Nfse\Dto\Nfse\InfDpsData;
 use Nfse\Enums\EmitenteDPS;
+use Nfse\Enums\IndicadorDestinatario;
+use Nfse\Enums\TipoReembolsoRepasseRessarcimento;
 
 class DpsValidator
 {
@@ -21,6 +23,7 @@ class DpsValidator
         $this->validateTomador($infDps, $errors);
         $this->validateValores($infDps, $errors);
         $this->validateServico($infDps, $errors);
+        $this->validateIbscbs($infDps, $errors);
 
         if (count($errors) > 0) {
             return ValidationResult::failure($errors);
@@ -138,6 +141,60 @@ class DpsValidator
         // Rule 276: atvEvento is required for item 12
         if (str_starts_with($cTribNac ?? '', '12') && $servico->atividadeEvento === null) {
             $errors[] = 'O grupo de informações de Atividade/Evento é obrigatório para o serviço informado.';
+        }
+    }
+
+    private function validateIbscbs(InfDpsData $infDps, array &$errors): void
+    {
+        $ibscbs = $infDps->ibscbs;
+        if ($ibscbs === null) {
+            return;
+        }
+
+        // Rule 542: IBS/CBS só pode ser declarado a partir da competência 01/01/2026
+        if ($infDps->dataCompetencia !== null && $infDps->dataCompetencia < '2026-01-01') {
+            $errors[] = 'As informações de IBS/CBS só podem ser declaradas a partir da data de competência 01/01/2026.';
+        }
+
+        // Rule 324: cNBS é obrigatório quando o grupo de IBS/CBS é informado
+        if ($infDps->servico?->codigoServico?->codigoNbs === null) {
+            $errors[] = 'O item da NBS é obrigatório quando o grupo de informações de IBS/CBS é informado.';
+        }
+
+        // Rule 549: gRefNFSe é obrigatório quando tpOper = 2 ou 3
+        if ($ibscbs->tipoOperacao?->exigeNfseReferenciada() && empty($ibscbs->chavesNfseReferenciadas)) {
+            $errors[] = 'O grupo de NFS-e referenciadas é obrigatório quando o tipo de operação for 2 ou 3.';
+        }
+
+        // Rule 554: o destinatário só deve ser identificado quando indDest = 1
+        if ($ibscbs->destinatario !== null && $ibscbs->indicadorDestinatario !== IndicadorDestinatario::DestinatarioDiverso) {
+            $errors[] = 'O destinatário do serviço só deve ser identificado quando o indicador de destinatário for 1.';
+        }
+
+        // Rule 627: os 3 primeiros dígitos do cClassTrib devem corresponder ao CST
+        if ($ibscbs->cst !== null && $ibscbs->codigoClassificacaoTributaria !== null
+            && ! str_starts_with($ibscbs->codigoClassificacaoTributaria, $ibscbs->cst)) {
+            $errors[] = 'O código de classificação tributária informado não pertence ao grupo do CST de IBS/CBS informado.';
+        }
+
+        $vServ = $infDps->valores?->valorServicoPrestado?->valorServico ?? 0;
+
+        foreach ($ibscbs->documentosReembolso ?? [] as $documento) {
+            // Rule 621: xTpReeRepRes só deve ser informado quando tpReeRepRes = 99
+            if ($documento->descricaoTipoReembolso !== null && $documento->tipoReembolso !== TipoReembolsoRepasseRessarcimento::Outros) {
+                $errors[] = 'A descrição do tipo de reembolso, repasse e ressarcimento só deve ser informada quando o tipo for 99.';
+            }
+
+            // Rule 618/619: a data de emissão deve ser igual ou posterior à data de competência
+            if ($documento->dataEmissaoDocumento !== null && $documento->dataCompetenciaDocumento !== null
+                && $documento->dataEmissaoDocumento < $documento->dataCompetenciaDocumento) {
+                $errors[] = 'A data de emissão do documento de reembolso deve ser igual ou posterior à sua data de competência.';
+            }
+
+            // Rule 622: o valor do reembolso deve ser menor ou igual ao valor do serviço prestado
+            if ($documento->valorReembolso !== null && $documento->valorReembolso > $vServ) {
+                $errors[] = 'O valor de reembolso, repasse e ressarcimento deve ser menor ou igual ao valor do serviço prestado.';
+            }
         }
     }
 }

--- a/src/Xml/DpsXmlBuilder.php
+++ b/src/Xml/DpsXmlBuilder.php
@@ -6,8 +6,10 @@ use DOMDocument;
 use DOMElement;
 use Nfse\Dto\Nfse\DpsData;
 use Nfse\Dto\Nfse\EnderecoData;
+use Nfse\Dto\Nfse\IbscbsData;
 use Nfse\Dto\Nfse\InfDpsData;
 use Nfse\Dto\Nfse\PrestadorData;
+use Nfse\Dto\Nfse\ReembolsoDocumentoData;
 use Nfse\Dto\Nfse\ServicoData;
 use Nfse\Dto\Nfse\TomadorData;
 use Nfse\Dto\Nfse\ValoresData;
@@ -47,9 +49,9 @@ class DpsXmlBuilder
         $this->appendElement($parent, 'nDPS', $data->numeroDps);
         $this->appendElement($parent, 'dCompet', $data->dataCompetencia);
         $this->appendElement($parent, 'tpEmit', $data->tipoEmitente);
-        $this->appendElement($parent, 'cLocEmi', $data->codigoLocalEmissao);
         $this->appendElement($parent, 'cMotivoEmisTI', $data->motivoEmissaoTomadorIntermediario);
         $this->appendElement($parent, 'chNFSeRej', $data->chaveNfseRejeitada);
+        $this->appendElement($parent, 'cLocEmi', $data->codigoLocalEmissao);
 
         if ($data->substituicao) {
             $subst = $this->dom->createElement('subst');
@@ -95,9 +97,7 @@ class DpsXmlBuilder
         }
 
         if ($data->ibscbs) {
-            $ibscbs = $this->dom->createElement('IBSCBS');
-            $this->appendElement($ibscbs, 'indZFMALC', $data->ibscbs->indicadorZfmAlc);
-            $parent->appendChild($ibscbs);
+            $this->buildIbscbs($parent, $data->ibscbs);
         }
     }
 
@@ -150,11 +150,19 @@ class DpsXmlBuilder
         $parent->appendChild($toma);
     }
 
-    private function buildEndereco(DOMElement $parent, EnderecoData $data): void
+    /**
+     * O endereço simples (obra, evento e imóvel) traz o CEP direto no lugar do grupo
+     * endNac e não informa o país no endereço no exterior.
+     */
+    private function buildEndereco(DOMElement $parent, EnderecoData $data, bool $enderecoSimples = false): void
     {
         $end = $this->dom->createElement('end');
 
-        if ($data->codigoMunicipio || $data->cep) {
+        if ($enderecoSimples) {
+            if (! $data->enderecoExterior) {
+                $this->appendElement($end, 'CEP', $data->cep);
+            }
+        } elseif ($data->codigoMunicipio || $data->cep) {
             $endNac = $this->dom->createElement('endNac');
             $this->appendElement($endNac, 'cMun', $data->codigoMunicipio);
             $this->appendElement($endNac, 'CEP', $data->cep);
@@ -163,7 +171,9 @@ class DpsXmlBuilder
 
         if ($data->enderecoExterior) {
             $endExt = $this->dom->createElement('endExt');
-            $this->appendElement($endExt, 'cPais', $data->enderecoExterior->codigoPais);
+            if (! $enderecoSimples) {
+                $this->appendElement($endExt, 'cPais', $data->enderecoExterior->codigoPais);
+            }
             $this->appendElement($endExt, 'cEndPost', $data->enderecoExterior->codigoEnderecamentoPostal);
             $this->appendElement($endExt, 'xCidade', $data->enderecoExterior->cidade);
             $this->appendElement($endExt, 'xEstProvReg', $data->enderecoExterior->estadoProvinciaRegiao);
@@ -395,6 +405,136 @@ class DpsXmlBuilder
         }
 
         $parent->appendChild($valores);
+    }
+
+    private function buildIbscbs(DOMElement $parent, IbscbsData $data): void
+    {
+        $ibscbs = $this->dom->createElement('IBSCBS');
+
+        $this->appendElement($ibscbs, 'finNFSe', $data->finalidadeNfse);
+        $this->appendElement($ibscbs, 'indFinal', $data->indicadorUsoConsumoPessoal);
+        $this->appendElement($ibscbs, 'cIndOp', $data->codigoIndicadorOperacao);
+        $this->appendElement($ibscbs, 'tpOper', $data->tipoOperacao);
+
+        if ($data->chavesNfseReferenciadas) {
+            $gRefNFSe = $this->dom->createElement('gRefNFSe');
+            foreach ($data->chavesNfseReferenciadas as $chave) {
+                $this->appendElement($gRefNFSe, 'refNFSe', $chave);
+            }
+            $ibscbs->appendChild($gRefNFSe);
+        }
+
+        $this->appendElement($ibscbs, 'tpEnteGov', $data->tipoEnteGovernamental);
+        $this->appendElement($ibscbs, 'indDest', $data->indicadorDestinatario);
+
+        if ($data->destinatario) {
+            $dest = $this->dom->createElement('dest');
+            $this->appendElement($dest, 'CNPJ', $data->destinatario->cnpj);
+            $this->appendElement($dest, 'CPF', $data->destinatario->cpf);
+            $this->appendElement($dest, 'NIF', $data->destinatario->nif);
+            $this->appendElement($dest, 'cNaoNIF', $data->destinatario->codigoNaoNif);
+            $this->appendElement($dest, 'xNome', $data->destinatario->nome);
+
+            if ($data->destinatario->endereco) {
+                $this->buildEndereco($dest, $data->destinatario->endereco);
+            }
+
+            $this->appendElement($dest, 'fone', $data->destinatario->telefone);
+            $this->appendElement($dest, 'email', $data->destinatario->email);
+            $ibscbs->appendChild($dest);
+        }
+
+        if ($data->imovel) {
+            $imovel = $this->dom->createElement('imovel');
+            $this->appendElement($imovel, 'inscImobFisc', $data->imovel->inscricaoImobiliariaFiscal);
+
+            if ($data->imovel->codigoCib) {
+                $this->appendElement($imovel, 'cCIB', $data->imovel->codigoCib);
+            } elseif ($data->imovel->endereco) {
+                $this->buildEndereco($imovel, $data->imovel->endereco, true);
+            }
+
+            $ibscbs->appendChild($imovel);
+        }
+
+        $valores = $this->dom->createElement('valores');
+
+        if ($data->documentosReembolso) {
+            $gReeRepRes = $this->dom->createElement('gReeRepRes');
+            foreach ($data->documentosReembolso as $documento) {
+                $this->buildDocumentoReembolso($gReeRepRes, $documento);
+            }
+            $valores->appendChild($gReeRepRes);
+        }
+
+        $trib = $this->dom->createElement('trib');
+        $gIbscbs = $this->dom->createElement('gIBSCBS');
+        $this->appendElement($gIbscbs, 'CST', $data->cst);
+        $this->appendElement($gIbscbs, 'cClassTrib', $data->codigoClassificacaoTributaria);
+        $this->appendElement($gIbscbs, 'cCredPres', $data->codigoCreditoPresumido);
+
+        if ($data->cstTributacaoRegular) {
+            $gTribRegular = $this->dom->createElement('gTribRegular');
+            $this->appendElement($gTribRegular, 'CSTReg', $data->cstTributacaoRegular);
+            $this->appendElement($gTribRegular, 'cClassTribReg', $data->codigoClassificacaoTributariaRegular);
+            $gIbscbs->appendChild($gTribRegular);
+        }
+
+        if ($data->percentualDiferimentoUf !== null || $data->percentualDiferimentoMunicipal !== null || $data->percentualDiferimentoCbs !== null) {
+            $gDif = $this->dom->createElement('gDif');
+            $this->appendElement($gDif, 'pDifUF', number_format((float) $data->percentualDiferimentoUf, 2, '.', ''));
+            $this->appendElement($gDif, 'pDifMun', number_format((float) $data->percentualDiferimentoMunicipal, 2, '.', ''));
+            $this->appendElement($gDif, 'pDifCBS', number_format((float) $data->percentualDiferimentoCbs, 2, '.', ''));
+            $gIbscbs->appendChild($gDif);
+        }
+
+        $trib->appendChild($gIbscbs);
+        $valores->appendChild($trib);
+        $ibscbs->appendChild($valores);
+
+        $parent->appendChild($ibscbs);
+    }
+
+    private function buildDocumentoReembolso(DOMElement $parent, ReembolsoDocumentoData $data): void
+    {
+        $documentos = $this->dom->createElement('documentos');
+
+        if ($data->chaveDfe) {
+            $dFeNacional = $this->dom->createElement('dFeNacional');
+            $this->appendElement($dFeNacional, 'tipoChaveDFe', $data->tipoChaveDfe);
+            $this->appendElement($dFeNacional, 'xTipoChaveDFe', $data->descricaoTipoChaveDfe);
+            $this->appendElement($dFeNacional, 'chaveDFe', $data->chaveDfe);
+            $documentos->appendChild($dFeNacional);
+        } elseif ($data->numeroDocumentoFiscal) {
+            $docFiscalOutro = $this->dom->createElement('docFiscalOutro');
+            $this->appendElement($docFiscalOutro, 'cMunDocFiscal', $data->codigoMunicipioDocumentoFiscal);
+            $this->appendElement($docFiscalOutro, 'nDocFiscal', $data->numeroDocumentoFiscal);
+            $this->appendElement($docFiscalOutro, 'xDocFiscal', $data->descricaoDocumentoFiscal);
+            $documentos->appendChild($docFiscalOutro);
+        } elseif ($data->numeroDocumento) {
+            $docOutro = $this->dom->createElement('docOutro');
+            $this->appendElement($docOutro, 'nDoc', $data->numeroDocumento);
+            $this->appendElement($docOutro, 'xDoc', $data->descricaoDocumento);
+            $documentos->appendChild($docOutro);
+        }
+
+        if ($data->fornecedor) {
+            $fornec = $this->dom->createElement('fornec');
+            $this->appendElement($fornec, 'CNPJ', $data->fornecedor->cnpj);
+            $this->appendElement($fornec, 'CPF', $data->fornecedor->cpf);
+            $this->appendElement($fornec, 'NIF', $data->fornecedor->nif);
+            $this->appendElement($fornec, 'cNaoNIF', $data->fornecedor->codigoNaoNif);
+            $this->appendElement($fornec, 'xNome', $data->fornecedor->nome);
+            $documentos->appendChild($fornec);
+        }
+
+        $this->appendElement($documentos, 'dtEmiDoc', $data->dataEmissaoDocumento);
+        $this->appendElement($documentos, 'dtCompDoc', $data->dataCompetenciaDocumento);
+        $this->appendElement($documentos, 'tpReeRepRes', $data->tipoReembolso);
+        $this->appendElement($documentos, 'xTpReeRepRes', $data->descricaoTipoReembolso);
+        $this->appendElement($documentos, 'vlrReeRepRes', $data->valorReembolso !== null ? number_format($data->valorReembolso, 2, '.', '') : null);
+
+        $parent->appendChild($documentos);
     }
 
     private function appendElement(DOMElement $parent, string $name, mixed $value): void

--- a/src/Xml/NfseXmlBuilder.php
+++ b/src/Xml/NfseXmlBuilder.php
@@ -6,6 +6,7 @@ use DOMDocument;
 use DOMElement;
 use Nfse\Dto\Nfse\EmitenteData;
 use Nfse\Dto\Nfse\EnderecoEmitenteData;
+use Nfse\Dto\Nfse\IbscbsNfseData;
 use Nfse\Dto\Nfse\InfNfseData;
 use Nfse\Dto\Nfse\NfseData;
 use Nfse\Dto\Nfse\ValoresNfseData;
@@ -69,6 +70,10 @@ class NfseXmlBuilder
             $this->buildValores($parent, $data->valores);
         }
 
+        if ($data->ibscbs) {
+            $this->buildIbscbs($parent, $data->ibscbs);
+        }
+
         if ($data->dps) {
             // The DpsXmlBuilder creates a full XML, we need to import the 'DPS' element
             $dpsXml = $this->dpsBuilder->build($data->dps);
@@ -116,12 +121,112 @@ class NfseXmlBuilder
     private function buildValores(DOMElement $parent, ValoresNfseData $data): void
     {
         $valores = $this->dom->createElement('valores');
-        $this->appendElement($valores, 'vBC', $data->baseCalculo !== null ? number_format($data->baseCalculo, 2, '.', '') : null);
-        $this->appendElement($valores, 'pAliqAplic', $data->aliquotaAplicada !== null ? number_format($data->aliquotaAplicada, 2, '.', '') : null);
-        $this->appendElement($valores, 'vISSQN', $data->valorIssqn !== null ? number_format($data->valorIssqn, 2, '.', '') : null);
-        $this->appendElement($valores, 'vTotalRet', $data->valorTotalRetido !== null ? number_format($data->valorTotalRetido, 2, '.', '') : null);
-        $this->appendElement($valores, 'vLiq', $data->valorLiquido !== null ? number_format($data->valorLiquido, 2, '.', '') : null);
+        $this->appendElement($valores, 'vBC', $this->formatValue($data->baseCalculo));
+        $this->appendElement($valores, 'pAliqAplic', $this->formatValue($data->aliquotaAplicada));
+        $this->appendElement($valores, 'vISSQN', $this->formatValue($data->valorIssqn));
+        $this->appendElement($valores, 'vTotalRet', $this->formatValue($data->valorTotalRetido));
+        $this->appendElement($valores, 'vLiq', $this->formatValue($data->valorLiquido));
         $parent->appendChild($valores);
+    }
+
+    private function buildIbscbs(DOMElement $parent, IbscbsNfseData $data): void
+    {
+        $ibscbs = $this->dom->createElement('IBSCBS');
+        $this->appendElement($ibscbs, 'cLocalidadeIncid', $data->codigoLocalidadeIncidencia);
+        $this->appendElement($ibscbs, 'xLocalidadeIncid', $data->nomeLocalidadeIncidencia);
+        $this->appendElement($ibscbs, 'pRedutor', $this->formatValue($data->percentualRedutor));
+
+        $valores = $this->dom->createElement('valores');
+        $this->appendElement($valores, 'vBC', $this->formatValue($data->baseCalculo));
+        $this->appendElement($valores, 'vCalcReeRepRes', $this->formatValue($data->valorCalculadoReembolso));
+
+        $uf = $this->dom->createElement('uf');
+        $this->appendElement($uf, 'pIBSUF', $this->formatValue($data->aliquotaIbsUf));
+        $this->appendElement($uf, 'pRedAliqUF', $this->formatValue($data->percentualReducaoAliquotaUf));
+        $this->appendElement($uf, 'pAliqEfetUF', $this->formatValue($data->aliquotaEfetivaUf));
+        $valores->appendChild($uf);
+
+        $mun = $this->dom->createElement('mun');
+        $this->appendElement($mun, 'pIBSMun', $this->formatValue($data->aliquotaIbsMunicipal));
+        $this->appendElement($mun, 'pRedAliqMun', $this->formatValue($data->percentualReducaoAliquotaMunicipal));
+        $this->appendElement($mun, 'pAliqEfetMun', $this->formatValue($data->aliquotaEfetivaMunicipal));
+        $valores->appendChild($mun);
+
+        $fed = $this->dom->createElement('fed');
+        $this->appendElement($fed, 'pCBS', $this->formatValue($data->aliquotaCbs));
+        $this->appendElement($fed, 'pRedAliqCBS', $this->formatValue($data->percentualReducaoAliquotaCbs));
+        $this->appendElement($fed, 'pAliqEfetCBS', $this->formatValue($data->aliquotaEfetivaCbs));
+        $valores->appendChild($fed);
+
+        $ibscbs->appendChild($valores);
+
+        $totCIBS = $this->dom->createElement('totCIBS');
+        $this->appendElement($totCIBS, 'vTotNF', $this->formatValue($data->valorTotalNota));
+
+        $gIBS = $this->dom->createElement('gIBS');
+        $this->appendElement($gIBS, 'vIBSTot', $this->formatValue($data->valorTotalIbs));
+
+        if ($data->valorCreditoPresumidoIbs !== null) {
+            $gIBSCredPres = $this->dom->createElement('gIBSCredPres');
+            $this->appendElement($gIBSCredPres, 'pCredPresIBS', $this->formatValue($data->aliquotaCreditoPresumidoIbs));
+            $this->appendElement($gIBSCredPres, 'vCredPresIBS', $this->formatValue($data->valorCreditoPresumidoIbs));
+            $gIBS->appendChild($gIBSCredPres);
+        }
+
+        $gIBSUFTot = $this->dom->createElement('gIBSUFTot');
+        $this->appendElement($gIBSUFTot, 'vDifUF', $this->formatValue($data->valorDiferimentoUf));
+        $this->appendElement($gIBSUFTot, 'vIBSUF', $this->formatValue($data->valorIbsUf));
+        $gIBS->appendChild($gIBSUFTot);
+
+        $gIBSMunTot = $this->dom->createElement('gIBSMunTot');
+        $this->appendElement($gIBSMunTot, 'vDifMun', $this->formatValue($data->valorDiferimentoMunicipal));
+        $this->appendElement($gIBSMunTot, 'vIBSMun', $this->formatValue($data->valorIbsMunicipal));
+        $gIBS->appendChild($gIBSMunTot);
+
+        $totCIBS->appendChild($gIBS);
+
+        $gCBS = $this->dom->createElement('gCBS');
+
+        if ($data->valorCreditoPresumidoCbs !== null) {
+            $gCBSCredPres = $this->dom->createElement('gCBSCredPres');
+            $this->appendElement($gCBSCredPres, 'pCredPresCBS', $this->formatValue($data->aliquotaCreditoPresumidoCbs));
+            $this->appendElement($gCBSCredPres, 'vCredPresCBS', $this->formatValue($data->valorCreditoPresumidoCbs));
+            $gCBS->appendChild($gCBSCredPres);
+        }
+
+        $this->appendElement($gCBS, 'vDifCBS', $this->formatValue($data->valorDiferimentoCbs));
+        $this->appendElement($gCBS, 'vCBS', $this->formatValue($data->valorCbs));
+        $totCIBS->appendChild($gCBS);
+
+        if ($data->valorTributacaoRegularCbs !== null) {
+            $gTribRegular = $this->dom->createElement('gTribRegular');
+            $this->appendElement($gTribRegular, 'pAliqEfeRegIBSUF', $this->formatValue($data->aliquotaEfetivaRegularIbsUf));
+            $this->appendElement($gTribRegular, 'vTribRegIBSUF', $this->formatValue($data->valorTributacaoRegularIbsUf));
+            $this->appendElement($gTribRegular, 'pAliqEfeRegIBSMun', $this->formatValue($data->aliquotaEfetivaRegularIbsMunicipal));
+            $this->appendElement($gTribRegular, 'vTribRegIBSMun', $this->formatValue($data->valorTributacaoRegularIbsMunicipal));
+            $this->appendElement($gTribRegular, 'pAliqEfeRegCBS', $this->formatValue($data->aliquotaEfetivaRegularCbs));
+            $this->appendElement($gTribRegular, 'vTribRegCBS', $this->formatValue($data->valorTributacaoRegularCbs));
+            $totCIBS->appendChild($gTribRegular);
+        }
+
+        if ($data->valorCompraGovCbs !== null) {
+            $gTribCompraGov = $this->dom->createElement('gTribCompraGov');
+            $this->appendElement($gTribCompraGov, 'pIBSUF', $this->formatValue($data->aliquotaCompraGovIbsUf));
+            $this->appendElement($gTribCompraGov, 'vIBSUF', $this->formatValue($data->valorCompraGovIbsUf));
+            $this->appendElement($gTribCompraGov, 'pIBSMun', $this->formatValue($data->aliquotaCompraGovIbsMunicipal));
+            $this->appendElement($gTribCompraGov, 'vIBSMun', $this->formatValue($data->valorCompraGovIbsMunicipal));
+            $this->appendElement($gTribCompraGov, 'pCBS', $this->formatValue($data->aliquotaCompraGovCbs));
+            $this->appendElement($gTribCompraGov, 'vCBS', $this->formatValue($data->valorCompraGovCbs));
+            $totCIBS->appendChild($gTribCompraGov);
+        }
+
+        $ibscbs->appendChild($totCIBS);
+        $parent->appendChild($ibscbs);
+    }
+
+    private function formatValue(?float $value): ?string
+    {
+        return $value !== null ? number_format($value, 2, '.', '') : null;
     }
 
     private function appendElement(DOMElement $parent, string $name, mixed $value): void

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -124,3 +124,44 @@ if (! function_exists('resolve')) {
         return app($abstract);
     }
 }
+
+if (! function_exists('validarContraSchema')) {
+    /**
+     * Valida um XML contra os esquemas oficiais publicados em references/schemas.
+     *
+     * O TSSerieDPS do pacote oficial usa uma expressão regular com lookahead, que não é
+     * aceita pela gramática de expressões do XML Schema e impede o libxml de compilar o
+     * esquema. A cópia usada aqui substitui apenas esse padrão.
+     */
+    function validarContraSchema(string $xml, string $schema): bool
+    {
+        $origem = __DIR__.'/../references/schemas';
+        $destino = sys_get_temp_dir().'/nfse-php-schemas';
+
+        if (! is_dir($destino)) {
+            mkdir($destino, 0777, true);
+        }
+
+        foreach (glob($origem.'/*.xsd') as $arquivo) {
+            $conteudo = str_replace('^(?!0{1,5}$)\d{1,5}$', '[0-9]{1,5}', file_get_contents($arquivo));
+            file_put_contents($destino.'/'.basename($arquivo), $conteudo);
+        }
+
+        $dom = new DOMDocument;
+        $dom->loadXML($xml);
+
+        $anterior = libxml_use_internal_errors(true);
+        $valido = $dom->schemaValidate($destino.'/'.$schema);
+
+        if (! $valido) {
+            foreach (libxml_get_errors() as $erro) {
+                fwrite(STDERR, trim($erro->message).PHP_EOL);
+            }
+        }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($anterior);
+
+        return $valido;
+    }
+}

--- a/tests/Unit/Validator/DpsValidatorIbscbsTest.php
+++ b/tests/Unit/Validator/DpsValidatorIbscbsTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Nfse\Tests\Unit\Validator;
+
+use Nfse\Dto\Nfse\DpsData;
+use Nfse\Validator\DpsValidator;
+
+function validarDpsComIbscbs(array $ibscbs, array $sobrescritas = []): array
+{
+    $infDps = array_replace([
+        'tpAmb' => 2,
+        'dhEmi' => '2026-03-10T10:00:00-03:00',
+        'verAplic' => '1.0',
+        'serie' => '1',
+        'nDPS' => '1001',
+        'dCompet' => '2026-03-10',
+        'tpEmit' => 1,
+        'cLocEmi' => '3550308',
+        'prest' => [
+            'CNPJ' => '12345678000199',
+            'xNome' => 'Prestador Exemplo Ltda',
+        ],
+        'serv' => [
+            'locPrest' => ['cLocPrestacao' => '3550308'],
+            'cServ' => [
+                'cTribNac' => '010201',
+                'xDescServ' => 'Analise de sistemas',
+                'cNBS' => '112011000',
+            ],
+        ],
+        'valores' => [
+            'vServPrest' => ['vServ' => 1000.00],
+            'trib' => ['tribMun.tribISSQN' => 1],
+        ],
+        'IBSCBS' => $ibscbs,
+    ], $sobrescritas);
+
+    return (new DpsValidator)->validate(new DpsData(['infDPS' => $infDps]))->errors;
+}
+
+function ibscbsValido(array $sobrescritas = []): array
+{
+    return array_replace([
+        'finNFSe' => '0',
+        'cIndOp' => '010101',
+        'indDest' => 0,
+        'valores' => [
+            'trib' => [
+                'gIBSCBS' => [
+                    'CST' => '000',
+                    'cClassTrib' => '000001',
+                ],
+            ],
+        ],
+    ], $sobrescritas);
+}
+
+it('accepts a consistent ibscbs group', function () {
+    expect(validarDpsComIbscbs(ibscbsValido()))->toBeEmpty();
+});
+
+it('rejects ibscbs before the 2026 competence', function () {
+    $errors = validarDpsComIbscbs(ibscbsValido(), ['dCompet' => '2025-12-31']);
+
+    expect($errors)->toContain('As informações de IBS/CBS só podem ser declaradas a partir da data de competência 01/01/2026.');
+});
+
+it('requires the nbs item when ibscbs is informed', function () {
+    $errors = validarDpsComIbscbs(ibscbsValido(), [
+        'serv' => [
+            'locPrest' => ['cLocPrestacao' => '3550308'],
+            'cServ' => [
+                'cTribNac' => '010201',
+                'xDescServ' => 'Analise de sistemas',
+            ],
+        ],
+    ]);
+
+    expect($errors)->toContain('O item da NBS é obrigatório quando o grupo de informações de IBS/CBS é informado.');
+});
+
+it('requires referenced nfse when the operation type is 2 or 3', function () {
+    $errors = validarDpsComIbscbs(ibscbsValido(['tpOper' => 2]));
+
+    expect($errors)->toContain('O grupo de NFS-e referenciadas é obrigatório quando o tipo de operação for 2 ou 3.');
+});
+
+it('rejects a destinatario when the destination indicator is not 1', function () {
+    $errors = validarDpsComIbscbs(ibscbsValido([
+        'dest' => [
+            'CNPJ' => '98765432000188',
+            'xNome' => 'Destinatario Exemplo Ltda',
+        ],
+    ]));
+
+    expect($errors)->toContain('O destinatário do serviço só deve ser identificado quando o indicador de destinatário for 1.');
+});
+
+it('rejects a cClassTrib outside the informed cst group', function () {
+    $errors = validarDpsComIbscbs(ibscbsValido([
+        'valores' => [
+            'trib' => [
+                'gIBSCBS' => [
+                    'CST' => '200',
+                    'cClassTrib' => '000001',
+                ],
+            ],
+        ],
+    ]));
+
+    expect($errors)->toContain('O código de classificação tributária informado não pertence ao grupo do CST de IBS/CBS informado.');
+});
+
+it('validates the reimbursement documents', function () {
+    $errors = validarDpsComIbscbs(ibscbsValido([
+        'valores' => [
+            'gReeRepRes' => [
+                'documentos' => [
+                    'docOutro' => ['nDoc' => '55', 'xDoc' => 'Recibo'],
+                    'dtEmiDoc' => '2026-01-10',
+                    'dtCompDoc' => '2026-02-10',
+                    'tpReeRepRes' => '01',
+                    'xTpReeRepRes' => 'Descricao indevida',
+                    'vlrReeRepRes' => 1500.00,
+                ],
+            ],
+            'trib' => [
+                'gIBSCBS' => [
+                    'CST' => '000',
+                    'cClassTrib' => '000001',
+                ],
+            ],
+        ],
+    ]));
+
+    expect($errors)->toContain('A descrição do tipo de reembolso, repasse e ressarcimento só deve ser informada quando o tipo for 99.')
+        ->toContain('A data de emissão do documento de reembolso deve ser igual ou posterior à sua data de competência.')
+        ->toContain('O valor de reembolso, repasse e ressarcimento deve ser menor ou igual ao valor do serviço prestado.');
+});

--- a/tests/Unit/Xml/DpsXmlBuilderIbscbsTest.php
+++ b/tests/Unit/Xml/DpsXmlBuilderIbscbsTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Nfse\Tests\Unit\Xml;
+
+use Nfse\Dto\Nfse\DpsData;
+use Nfse\Support\IdGenerator;
+use Nfse\Xml\DpsXmlBuilder;
+
+function dpsComIbscbs(array $ibscbs): DpsData
+{
+    return new DpsData([
+        '@attributes' => ['versao' => '1.01'],
+        'infDPS' => [
+            '@attributes' => ['Id' => IdGenerator::generateDpsId('12345678000199', '3550308', '1', '1001')],
+            'tpAmb' => 2,
+            'dhEmi' => '2026-03-10T10:00:00-03:00',
+            'verAplic' => '1.0',
+            'serie' => '1',
+            'nDPS' => '1001',
+            'dCompet' => '2026-03-10',
+            'tpEmit' => 1,
+            'cLocEmi' => '3550308',
+            'prest' => [
+                'CNPJ' => '12345678000199',
+                'IM' => '12345',
+                'xNome' => 'Prestador Exemplo Ltda',
+                'regTrib' => [
+                    'opSimpNac' => 3,
+                    'regEspTrib' => 0,
+                ],
+            ],
+            'toma' => [
+                'CPF' => '11122233344',
+                'xNome' => 'Tomador Exemplo',
+            ],
+            'serv' => [
+                'locPrest' => ['cLocPrestacao' => '3550308'],
+                'cServ' => [
+                    'cTribNac' => '010201',
+                    'xDescServ' => 'Analise de sistemas',
+                    'cNBS' => '112011000',
+                ],
+            ],
+            'valores' => [
+                'vServPrest' => ['vServ' => 1000.00],
+                'trib' => [
+                    'tribMun.tribISSQN' => 1,
+                    'tribMun.tpRetISSQN' => 1,
+                    'tribMun.pAliq' => 5.00,
+                    'totTrib.indTotTrib' => 0,
+                ],
+            ],
+            'IBSCBS' => $ibscbs,
+        ],
+    ]);
+}
+
+it('builds a schema valid dps with the complete ibscbs group', function () {
+    $dps = dpsComIbscbs([
+        'finNFSe' => '0',
+        'indFinal' => 0,
+        'cIndOp' => '010101',
+        'tpOper' => 2,
+        'gRefNFSe' => [
+            'refNFSe' => [
+                '12345678901234567890123456789012345678901234567890',
+                '09876543210987654321098765432109876543210987654321',
+            ],
+        ],
+        'tpEnteGov' => 1,
+        'indDest' => 1,
+        'dest' => [
+            'CNPJ' => '98765432000188',
+            'xNome' => 'Destinatario Exemplo Ltda',
+            'end' => [
+                'endNac' => [
+                    'cMun' => '3550308',
+                    'CEP' => '01001000',
+                ],
+                'xLgr' => 'Praca da Se',
+                'nro' => '100',
+                'xBairro' => 'Se',
+            ],
+            'email' => 'destinatario@exemplo.com.br',
+        ],
+        'imovel' => [
+            'inscImobFisc' => '1234567890',
+            'end' => [
+                'cep' => '01001000',
+                'xLgr' => 'Rua do Imovel',
+                'nro' => '200',
+                'xBairro' => 'Centro',
+            ],
+        ],
+        'valores' => [
+            'gReeRepRes' => [
+                'documentos' => [
+                    [
+                        'dFeNacional' => [
+                            'tipoChaveDFe' => 1,
+                            'chaveDFe' => '12345678901234567890123456789012345678901234567890',
+                        ],
+                        'fornec' => [
+                            'CNPJ' => '11222333000144',
+                            'xNome' => 'Fornecedor Exemplo Ltda',
+                        ],
+                        'dtEmiDoc' => '2026-02-10',
+                        'dtCompDoc' => '2026-02-01',
+                        'tpReeRepRes' => '01',
+                        'vlrReeRepRes' => 150.00,
+                    ],
+                    [
+                        'docOutro' => [
+                            'nDoc' => '55',
+                            'xDoc' => 'Recibo de despesa',
+                        ],
+                        'dtEmiDoc' => '2026-02-15',
+                        'dtCompDoc' => '2026-02-15',
+                        'tpReeRepRes' => '99',
+                        'xTpReeRepRes' => 'Reembolso de despesa por conta e ordem',
+                        'vlrReeRepRes' => 50.00,
+                    ],
+                ],
+            ],
+            'trib' => [
+                'gIBSCBS' => [
+                    'CST' => '200',
+                    'cClassTrib' => '200011',
+                    'cCredPres' => '01',
+                    'gTribRegular' => [
+                        'CSTReg' => '000',
+                        'cClassTribReg' => '000001',
+                    ],
+                    'gDif' => [
+                        'pDifUF' => 10.00,
+                        'pDifMun' => 10.00,
+                        'pDifCBS' => 5.00,
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $xml = (new DpsXmlBuilder)->build($dps);
+
+    expect(validarContraSchema($xml, 'DPS_v1.01.xsd'))->toBeTrue()
+        ->and($xml)->toContain('<cIndOp>010101</cIndOp>')
+        ->and($xml)->toContain('<cClassTrib>200011</cClassTrib>')
+        ->and($xml)->toContain('<xTpReeRepRes>Reembolso de despesa por conta e ordem</xTpReeRepRes>')
+        ->and($xml)->toContain('<vlrReeRepRes>150.00</vlrReeRepRes>')
+        ->and($xml)->toContain('<pDifCBS>5.00</pDifCBS>');
+});
+
+it('builds a schema valid dps with the minimum ibscbs group', function () {
+    $dps = dpsComIbscbs([
+        'finNFSe' => '0',
+        'cIndOp' => '010101',
+        'indDest' => 0,
+        'valores' => [
+            'trib' => [
+                'gIBSCBS' => [
+                    'CST' => '000',
+                    'cClassTrib' => '000001',
+                ],
+            ],
+        ],
+    ]);
+
+    $xml = (new DpsXmlBuilder)->build($dps);
+
+    expect(validarContraSchema($xml, 'DPS_v1.01.xsd'))->toBeTrue()
+        ->and($xml)->toContain('<IBSCBS><finNFSe>0</finNFSe><cIndOp>010101</cIndOp><indDest>0</indDest>')
+        ->and($xml)->toContain('<gIBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib></gIBSCBS>')
+        ->and($xml)->not()->toContain('<gRefNFSe>')
+        ->and($xml)->not()->toContain('<dest>')
+        ->and($xml)->not()->toContain('<imovel>')
+        ->and($xml)->not()->toContain('<gDif>');
+});
+
+it('uses cCIB instead of the address when the property is registered', function () {
+    $dps = dpsComIbscbs([
+        'finNFSe' => '0',
+        'cIndOp' => '010101',
+        'indDest' => 0,
+        'imovel' => [
+            'cCIB' => '12345678',
+            'end' => [
+                'cep' => '01001000',
+                'xLgr' => 'Rua do Imovel',
+                'nro' => '200',
+                'xBairro' => 'Centro',
+            ],
+        ],
+        'valores' => [
+            'trib' => [
+                'gIBSCBS' => [
+                    'CST' => '000',
+                    'cClassTrib' => '000001',
+                ],
+            ],
+        ],
+    ]);
+
+    $xml = (new DpsXmlBuilder)->build($dps);
+
+    expect(validarContraSchema($xml, 'DPS_v1.01.xsd'))->toBeTrue()
+        ->and($xml)->toContain('<imovel><cCIB>12345678</cCIB></imovel>');
+});

--- a/tests/Unit/Xml/NfseXmlParserIbscbsTest.php
+++ b/tests/Unit/Xml/NfseXmlParserIbscbsTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Nfse\Tests\Unit\Xml;
+
+use Nfse\Xml\NfseXmlBuilder;
+use Nfse\Xml\NfseXmlParser;
+
+function nfseXmlComIbscbs(): string
+{
+    return <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<NFSe xmlns="http://www.sped.fazenda.gov.br/nfse" versao="1.01">
+  <infNFSe Id="NFS12345678901234567890123456789012345678901234567890">
+    <xLocEmi>Sao Paulo</xLocEmi>
+    <xLocPrestacao>Sao Paulo</xLocPrestacao>
+    <nNFSe>1001</nNFSe>
+    <cLocIncid>3550308</cLocIncid>
+    <xLocIncid>Sao Paulo</xLocIncid>
+    <xTribNac>Analise de sistemas</xTribNac>
+    <verAplic>1.0</verAplic>
+    <ambGer>1</ambGer>
+    <tpEmis>1</tpEmis>
+    <procEmi>1</procEmi>
+    <cStat>100</cStat>
+    <dhProc>2026-03-10T10:00:00-03:00</dhProc>
+    <nDFSe>500</nDFSe>
+    <valores>
+      <vBC>1000.00</vBC>
+      <pAliqAplic>5.00</pAliqAplic>
+      <vISSQN>50.00</vISSQN>
+      <vLiq>950.00</vLiq>
+    </valores>
+    <IBSCBS>
+      <cLocalidadeIncid>3550308</cLocalidadeIncid>
+      <xLocalidadeIncid>Sao Paulo</xLocalidadeIncid>
+      <valores>
+        <vBC>950.00</vBC>
+        <vCalcReeRepRes>50.00</vCalcReeRepRes>
+        <uf>
+          <pIBSUF>0.10</pIBSUF>
+          <pRedAliqUF>30.00</pRedAliqUF>
+          <pAliqEfetUF>0.07</pAliqEfetUF>
+        </uf>
+        <mun>
+          <pIBSMun>0.05</pIBSMun>
+          <pAliqEfetMun>0.05</pAliqEfetMun>
+        </mun>
+        <fed>
+          <pCBS>0.90</pCBS>
+          <pAliqEfetCBS>0.90</pAliqEfetCBS>
+        </fed>
+      </valores>
+      <totCIBS>
+        <vTotNF>950.00</vTotNF>
+        <gIBS>
+          <vIBSTot>1.14</vIBSTot>
+          <gIBSUFTot>
+            <vDifUF>0.07</vDifUF>
+            <vIBSUF>0.67</vIBSUF>
+          </gIBSUFTot>
+          <gIBSMunTot>
+            <vIBSMun>0.47</vIBSMun>
+          </gIBSMunTot>
+        </gIBS>
+        <gCBS>
+          <vCBS>8.55</vCBS>
+        </gCBS>
+      </totCIBS>
+    </IBSCBS>
+  </infNFSe>
+</NFSe>
+XML;
+}
+
+it('parses the ibscbs group calculated by the national system', function () {
+    $nfse = (new NfseXmlParser)->parse(nfseXmlComIbscbs());
+
+    $ibscbs = $nfse->infNfse->ibscbs;
+
+    expect($ibscbs)->not()->toBeNull()
+        ->and($ibscbs->codigoLocalidadeIncidencia)->toBe('3550308')
+        ->and($ibscbs->nomeLocalidadeIncidencia)->toBe('Sao Paulo')
+        ->and($ibscbs->baseCalculo)->toBe(950.00)
+        ->and($ibscbs->valorCalculadoReembolso)->toBe(50.00)
+        ->and($ibscbs->aliquotaIbsUf)->toBe(0.10)
+        ->and($ibscbs->percentualReducaoAliquotaUf)->toBe(30.00)
+        ->and($ibscbs->aliquotaEfetivaUf)->toBe(0.07)
+        ->and($ibscbs->aliquotaCbs)->toBe(0.90)
+        ->and($ibscbs->valorTotalNota)->toBe(950.00)
+        ->and($ibscbs->valorTotalIbs)->toBe(1.14)
+        ->and($ibscbs->valorDiferimentoUf)->toBe(0.07)
+        ->and($ibscbs->valorIbsUf)->toBe(0.67)
+        ->and($ibscbs->valorIbsMunicipal)->toBe(0.47)
+        ->and($ibscbs->valorCbs)->toBe(8.55)
+        ->and($ibscbs->percentualRedutor)->toBeNull()
+        ->and($ibscbs->valorCreditoPresumidoIbs)->toBeNull();
+});
+
+it('serializes the ibscbs group back after the valores group', function () {
+    $nfse = (new NfseXmlParser)->parse(nfseXmlComIbscbs());
+
+    $xml = (new NfseXmlBuilder)->build($nfse);
+
+    expect($xml)->toContain('<cLocalidadeIncid>3550308</cLocalidadeIncid>')
+        ->and($xml)->toContain('<uf><pIBSUF>0.10</pIBSUF><pRedAliqUF>30.00</pRedAliqUF><pAliqEfetUF>0.07</pAliqEfetUF></uf>')
+        ->and($xml)->toContain('<mun><pIBSMun>0.05</pIBSMun><pAliqEfetMun>0.05</pAliqEfetMun></mun>')
+        ->and($xml)->toContain('<gCBS><vCBS>8.55</vCBS></gCBS>')
+        ->and($xml)->not()->toContain('<gTribRegular>')
+        ->and($xml)->not()->toContain('<gTribCompraGov>')
+        ->and(strpos($xml, '<vLiq>950.00</vLiq>'))->toBeLessThan(strpos($xml, '<IBSCBS>'));
+});
+
+it('keeps the ibscbs group null when the nfse does not carry it', function () {
+    $xml = str_replace('<IBSCBS>', '<naoIBSCBS>', nfseXmlComIbscbs());
+    $xml = str_replace('</IBSCBS>', '</naoIBSCBS>', $xml);
+
+    expect((new NfseXmlParser)->parse($xml)->infNfse->ibscbs)->toBeNull();
+});


### PR DESCRIPTION
Implementa o grupo `IBSCBS` conforme o pacote de esquemas **AnexoVI v1.01.03 (NT 004)**, que é o único com XSD publicado pelo portal da NFS-e, nos dois sentidos: as informações declaradas pelo emitente na DPS e os valores calculados pelo Sistema Nacional que voltam na NFS-e.

## Situação anterior

O pacote já tinha um esboço do grupo, mas ele veio de uma versão preliminar da NT 007: o `IbscbsData` declarava um único campo, `indZFMALC`, e o `DpsXmlBuilder` o emitia. Esse campo não existe no XSD versionado em `references/schemas/` nem no Anexo I de 09/02/2026. Na prática, quem preenchesse `ibscbs` gerava um XML rejeitado pelo esquema.

A especificação completa já estava no repositório desde a inclusão dos XSDs — faltava o código.

## O que entra

**Lado DPS (declarado)** — `IbscbsData` reescrito no padrão achatado com dot notation que o `TributacaoData` já usa, cobrindo a árvore inteira:

`finNFSe`, `indFinal`, `cIndOp`, `tpOper`, `gRefNFSe`, `tpEnteGov`, `indDest`, `dest`, `imovel`, `gReeRepRes/documentos` e `gIBSCBS` (`CST`, `cClassTrib`, `cCredPres`, `gTribRegular`, `gDif`).

O `dest` reaproveita o `TomadorData` (o `TCRTCInfoDest` é subconjunto dele), o `fornec` reaproveita o `FornecedorData` e os endereços reaproveitam o `EnderecoData`. Só dois DTOs novos foram necessários: `ImovelData` e `ReembolsoDocumentoData`.

**Lado NFS-e (calculado)** — novo `IbscbsNfseData`, com localidade de incidência, base de cálculo, alíquotas nominais e efetivas de UF/município/União, totalizadores de IBS e CBS, crédito presumido, diferimento, tributação regular e compras governamentais. O `NfseXmlParser` não precisou de mudança: passou a ler o grupo assim que o `InfNfseData` ganhou a propriedade.

**Enums** — `TipoOperacaoRtc`, `TipoEnteGovernamental`, `IndicadorDestinatario`, `TipoChaveDFe` e `TipoReembolsoRepasseRessarcimento`. `CST`, `cClassTrib`, `cCredPres` e `cIndOp` ficaram como string com o domínio no docblock: são tabelas de código externas (Anexos VII e VIII), revisadas a cada NT, e não domínios fechados.

**Validação** — o `DpsValidator` ganhou as regras de negócio do grupo que não dependem de tabela externa:

| Regra | Verificação |
|---|---|
| RN 324 | `IBSCBS` informado exige o item da NBS |
| RN 542 | `IBSCBS` só a partir da competência 01/01/2026 |
| RN 549 | `gRefNFSe` obrigatório quando `tpOper` for 2 ou 3 |
| RN 554 | `dest` só quando `indDest = 1` |
| RN 618/619 | `dtEmiDoc` igual ou posterior a `dtCompDoc` |
| RN 621 | `xTpReeRepRes` só quando `tpReeRepRes = 99` |
| RN 622 | `vlrReeRepRes` menor ou igual ao valor do serviço |
| RN 627 | os 3 primeiros dígitos de `cClassTrib` devem bater com o `CST` |

## Correções que apareceram no caminho

Ao validar o XML gerado contra o XSD oficial, dois problemas anteriores vieram à tona:

- **Ordem de `cLocEmi`.** O builder o serializava antes de `cMotivoEmisTI` e `chNFSeRej`, invertendo a sequência do `TCInfDPS`. Toda DPS emitida por tomador ou intermediário saía inválida.
- **Grupos repetíveis com uma ocorrência.** A conversão SimpleXML → JSON devolve um array associativo em vez de uma lista, e o `ArrayCaster` acabava iterando sobre os valores escalares. A correção foi feita no próprio caster, então também resolve o `vDedRed/documentos` que já existia.

## Testes

`tests/Unit/Xml/DpsXmlBuilderIbscbsTest.php` valida o XML gerado contra o `DPS_v1.01.xsd` de verdade, com `DOMDocument::schemaValidate` — grupo completo (destinatário, imóvel, dois documentos de reembolso, tributação regular e diferimento), grupo mínimo e a escolha entre `cCIB` e endereço do imóvel. Qualquer erro de ordem, cardinalidade ou formato derruba o teste.

Vale registrar um detalhe do pacote oficial: o `TSSerieDPS` usa `^(?!0{1,5}$)\d{1,5}$`, um lookahead do Perl que a gramática de expressões do XML Schema não aceita, e por isso o libxml se recusa a compilar o esquema inteiro. O helper em `tests/Pest.php` substitui apenas esse padrão numa cópia temporária dos XSDs. É um defeito da publicação, não do repositório.

Também entram `tests/Unit/Xml/NfseXmlParserIbscbsTest.php` (leitura do grupo calculado e reserialização) e `tests/Unit/Validator/DpsValidatorIbscbsTest.php` (um caso por regra).

Suíte completa: **212 testes, 777 asserções, sem regressão**. O PHPStan continua com os mesmos 10 erros pré-existentes em `Http/Client`, nenhum introduzido aqui.

## Fora do escopo

A **NT 009/2026 (leiaute v1.04.00)** — `gIBSCBSAjuste`, `finNFSe` com domínio 0/1/2, CNPJ alfanumérico e `vAjusteBC` unificando `vDedRed` com `gReeRepRes`. Não há XSD publicado nem prazo divulgado, e as mudanças quebram DTOs existentes. Faz mais sentido tratar quando sair o pacote de esquemas correspondente.

Validação de `cClassTrib` e `cIndOp` contra os Anexos VII e VIII também ficou de fora: exigiria embarcar tabelas grandes que precisam ser revisadas a cada nota técnica.

## Breaking change

Removido o `IbscbsData::$indicadorZfmAlc` e a emissão do elemento `indZFMALC`. Como o campo não existe no esquema, qualquer código que dependia dele já estava gerando XML rejeitado.

## Exemplo

`examples/contribuinte/emitir_ibscbs.php` mostra uma emissão tributada simples (`CST 000`, `cClassTrib 000001`) e a leitura dos valores calculados que voltam na NFS-e.
