### PR TITLE
feat: baixa DANFSe pelo endpoint do município quando mapeado

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Alguns municípios utilizam servidores próprios, mas seguem rigorosamente o con
 | :-------- | :-- | :--------- | :--------------------------------------------------------------- |
 | Catanduva | SP  | ✅ Testado | Utiliza infraestrutura própria (RLZ) seguindo contrato nacional. |
 
+Para esses municípios o `downloadDanfse()` também busca o PDF no servidor da própria prefeitura
+(`{endpoint}/danfse/{chaveAcesso}/pdf`), em vez do ambiente nacional (que frequentemente responde 503).
+A chamada não muda: basta informar o `codigoMunicipio` no `NfseContext`.
+
 #### Exemplo com Endpoint Customizado:
 
 O pacote também permite que você informe endpoints próprios caso você queira usar um servidor diferente.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ Para esses municípios o `downloadDanfse()` também busca o PDF no servidor da p
 (`{endpoint}/danfse/{chaveAcesso}/pdf`), em vez do ambiente nacional (que frequentemente responde 503).
 A chamada não muda: basta informar o `codigoMunicipio` no `NfseContext`.
 
+Para os demais municípios (que passam pelo ambiente nacional), as consultas e downloads são repetidos
+automaticamente até 2 vezes quando o servidor responde 502/503/504 ou derruba a conexão, com backoff de
+1s e 2s. Envios (POST) nunca são repetidos, para não duplicar NFS-e ou evento.
+
 #### Exemplo com Endpoint Customizado:
 
 O pacote também permite que você informe endpoints próprios caso você queira usar um servidor diferente.

--- a/src/Http/Client/AdnClient.php
+++ b/src/Http/Client/AdnClient.php
@@ -17,6 +17,7 @@ use Nfse\Enums\TipoNsu;
 use Nfse\Http\Contracts\AdnDanfseInterface;
 use Nfse\Http\Exceptions\NfseApiException;
 use Nfse\Http\NfseContext;
+use Nfse\Http\Retry;
 use Nfse\Support\SefinEndpointResolver;
 
 class AdnClient implements AdnDanfseInterface
@@ -61,6 +62,7 @@ class AdnClient implements AdnDanfseInterface
 
         return new Client([
             'base_uri' => $baseUrl,
+            'handler' => Retry::stack(),
             'curl' => [
                 CURLOPT_SSLCERTTYPE => 'P12',
                 CURLOPT_SSLCERT => $this->resolveCertificatePath(),

--- a/src/Http/Client/AdnClient.php
+++ b/src/Http/Client/AdnClient.php
@@ -17,6 +17,7 @@ use Nfse\Enums\TipoNsu;
 use Nfse\Http\Contracts\AdnDanfseInterface;
 use Nfse\Http\Exceptions\NfseApiException;
 use Nfse\Http\NfseContext;
+use Nfse\Support\SefinEndpointResolver;
 
 class AdnClient implements AdnDanfseInterface
 {
@@ -226,8 +227,13 @@ class AdnClient implements AdnDanfseInterface
      */
     public function obterDanfse(string $chaveAcesso): string
     {
+        // Municípios com endpoint próprio servem o PDF na mesma base do envio.
+        // URI absoluta faz o Guzzle ignorar o base_uri nacional.
+        $url = (new SefinEndpointResolver)->resolveDanfse($this->context, $chaveAcesso)
+            ?? "/danfse/{$chaveAcesso}";
+
         try {
-            $response = $this->httpClient->get("/danfse/{$chaveAcesso}");
+            $response = $this->httpClient->get($url);
 
             return $response->getBody()->getContents();
         } catch (\GuzzleHttp\Exception\RequestException $e) {

--- a/src/Http/Client/CncClient.php
+++ b/src/Http/Client/CncClient.php
@@ -9,6 +9,7 @@ use Nfse\Dto\Http\MensagemProcessamentoDto;
 use Nfse\Enums\TipoAmbiente;
 use Nfse\Http\Exceptions\NfseApiException;
 use Nfse\Http\NfseContext;
+use Nfse\Http\Retry;
 
 class CncClient
 {
@@ -52,6 +53,7 @@ class CncClient
 
         return new Client([
             'base_uri' => $baseUrl,
+            'handler' => Retry::stack(),
             'curl' => [
                 CURLOPT_SSLCERTTYPE => 'P12',
                 CURLOPT_SSLCERT => $this->resolveCertificatePath(),

--- a/src/Http/Client/SefinClient.php
+++ b/src/Http/Client/SefinClient.php
@@ -13,6 +13,7 @@ use Nfse\Dto\Http\RegistroEventoResponse;
 use Nfse\Http\Contracts\SefinNacionalInterface;
 use Nfse\Http\Exceptions\NfseApiException;
 use Nfse\Http\NfseContext;
+use Nfse\Http\Retry;
 use Nfse\Support\SefinEndpointResolver;
 
 class SefinClient implements SefinNacionalInterface
@@ -53,6 +54,7 @@ class SefinClient implements SefinNacionalInterface
     {
         return new Client([
             'base_uri' => rtrim($this->baseUrl, '/') . '/',
+            'handler' => Retry::stack(),
             'curl' => [
                 CURLOPT_SSLCERTTYPE => 'P12',
                 CURLOPT_SSLCERT => $this->resolveCertificatePath(),

--- a/src/Http/Retry.php
+++ b/src/Http/Retry.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Nfse\Http;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Handler do Guzzle que repete a requisição nas instabilidades do ambiente
+ * nacional (502/503/504 e queda de conexão), com o backoff exponencial padrão
+ * do Guzzle (1s, 2s).
+ *
+ * Só repete métodos idempotentes: reenviar um POST duplicaria NFS-e ou evento.
+ */
+class Retry
+{
+    private const MAX_RETRIES = 2;
+
+    private const RETRY_STATUS = [502, 503, 504];
+
+    public static function stack(?callable $handler = null): HandlerStack
+    {
+        $stack = HandlerStack::create($handler);
+
+        $stack->push(Middleware::retry(static function (
+            int $retries,
+            RequestInterface $request,
+            ?ResponseInterface $response = null,
+            ?\Throwable $exception = null
+        ): bool {
+            if ($retries >= self::MAX_RETRIES || ! in_array($request->getMethod(), ['GET', 'HEAD'], true)) {
+                return false;
+            }
+
+            return $exception instanceof ConnectException
+                || in_array($response?->getStatusCode(), self::RETRY_STATUS, true);
+        }));
+
+        return $stack;
+    }
+}

--- a/src/Support/SefinEndpointResolver.php
+++ b/src/Support/SefinEndpointResolver.php
@@ -49,4 +49,17 @@ class SefinEndpointResolver implements EndpointResolver
             ? $endpoint->production
             : $endpoint->homologation;
     }
+
+    /**
+     * URL do DANFSe no endpoint próprio do município, ou null quando o município
+     * não possui endpoint mapeado (nesse caso o download segue pelo ADN nacional).
+     */
+    public function resolveDanfse(NfseContext $context, string $chaveAcesso): ?string
+    {
+        if (! $context->codigoMunicipio || ! isset(self::ENDPOINTS[$context->codigoMunicipio])) {
+            return null;
+        }
+
+        return rtrim($this->resolve($context), '/')."/danfse/{$chaveAcesso}/pdf";
+    }
 }

--- a/tests/Unit/Http/Client/AdnClientTest.php
+++ b/tests/Unit/Http/Client/AdnClientTest.php
@@ -14,13 +14,15 @@ use ReflectionClass;
 
 class AdnClientTest extends TestCase
 {
-    private function createClientWithMock(array $responses): AdnClient
+    private MockHandler $mock;
+
+    private function createClientWithMock(array $responses, ?NfseContext $context = null): AdnClient
     {
-        $mock = new MockHandler($responses);
-        $handlerStack = HandlerStack::create($mock);
+        $this->mock = new MockHandler($responses);
+        $handlerStack = HandlerStack::create($this->mock);
         $httpClient = new Client(['handler' => $handlerStack]);
 
-        $context = new NfseContext(
+        $context ??= new NfseContext(
             TipoAmbiente::Homologacao,
             'fake/path.pfx',
             'password'
@@ -85,6 +87,30 @@ class AdnClientTest extends TestCase
         $response = $client->obterDanfse('CHAVE123');
 
         $this->assertEquals($pdfContent, $response);
+        $this->assertEquals('/danfse/CHAVE123', (string) $this->mock->getLastRequest()->getUri());
+    }
+
+    public function test_obter_danfse_usa_endpoint_do_municipio()
+    {
+        $pdfContent = '%PDF-1.4';
+
+        $client = $this->createClientWithMock(
+            [new Response(200, [], $pdfContent)],
+            new NfseContext(
+                TipoAmbiente::Producao,
+                'fake/path.pfx',
+                'password',
+                codigoMunicipio: '3511102'
+            )
+        );
+
+        $response = $client->obterDanfse('CHAVE123');
+
+        $this->assertEquals($pdfContent, $response);
+        $this->assertEquals(
+            'https://164.152.60.237/nota/nacional/danfse/CHAVE123/pdf',
+            (string) $this->mock->getLastRequest()->getUri()
+        );
     }
 
     public function test_consultar_eventos_contribuinte()

--- a/tests/Unit/Http/RetryTest.php
+++ b/tests/Unit/Http/RetryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ServerException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+use Nfse\Http\Retry;
+
+it('retries a GET when the national environment answers 503', function () {
+    $mock = new MockHandler([
+        new Response(503),
+        new Response(200, [], '%PDF-1.7'),
+    ]);
+
+    $response = (new Client(['handler' => Retry::stack($mock)]))->get('/danfse/123');
+
+    expect($response->getStatusCode())->toBe(200)
+        ->and((string) $response->getBody())->toBe('%PDF-1.7')
+        ->and($mock->count())->toBe(0);
+});
+
+it('gives up after the retry limit', function () {
+    $mock = new MockHandler([
+        new Response(503),
+        new Response(503),
+        new Response(503),
+    ]);
+
+    expect(fn () => (new Client(['handler' => Retry::stack($mock)]))->get('/danfse/123'))
+        ->toThrow(ServerException::class);
+
+    expect($mock->count())->toBe(0);
+});
+
+it('never retries a POST, to avoid duplicating NFS-e', function () {
+    $mock = new MockHandler([
+        new Response(503),
+        new Response(200, [], 'ok'),
+    ]);
+
+    expect(fn () => (new Client(['handler' => Retry::stack($mock)]))->post('/nfse'))
+        ->toThrow(ServerException::class);
+
+    expect($mock->count())->toBe(1);
+});

--- a/tests/Unit/Support/EndpointResolverTest.php
+++ b/tests/Unit/Support/EndpointResolverTest.php
@@ -76,3 +76,30 @@ it('resolves custom endpoint when provided in context', function () {
     expect($resolver->resolve($context))
         ->toBe('https://custom.api.com/homo');
 });
+
+it('resolves danfse url on the municipality endpoint', function () {
+    $context = new NfseContext(
+        ambiente: TipoAmbiente::Producao,
+        certificatePath: '/tmp/cert.pfx',
+        certificatePassword: '123456',
+        codigoMunicipio: '3511102'
+    );
+
+    $resolver = new SefinEndpointResolver();
+    expect($resolver->resolveDanfse($context, 'CHAVE123'))
+        ->toBe('https://164.152.60.237/nota/nacional/danfse/CHAVE123/pdf');
+});
+
+it('resolves null danfse url when municipio has no mapped endpoint', function () {
+    $context = new NfseContext(
+        ambiente: TipoAmbiente::Producao,
+        certificatePath: '/tmp/cert.pfx',
+        certificatePassword: '123456'
+    );
+
+    $resolver = new SefinEndpointResolver();
+    expect($resolver->resolveDanfse($context, 'CHAVE123'))->toBeNull();
+
+    $context->codigoMunicipio = '3550308';
+    expect($resolver->resolveDanfse($context, 'CHAVE123'))->toBeNull();
+});


### PR DESCRIPTION
## Problema

O download do DANFSe sempre vai para o ambiente nacional (`AdnClient::obterDanfse` → `adn.nfse.gov.br/danfse/{chave}`), que anda retornando **503** com frequência (#50).

Municípios com infraestrutura própria — que recebem a NFS-e e retransmitem para o nacional, como Catanduva/SP — servem o PDF na mesma base usada no envio:

```
{endpoint}/danfse/{chaveAcesso}/pdf
```

Ou seja, a lib já resolvia o endpoint da prefeitura para emissão/consulta, mas ignorava isso no PDF.

## Mudança

- `SefinEndpointResolver::resolveDanfse()`: devolve a URL do DANFSe no endpoint do município quando o `codigoMunicipio` está na tabela `ENDPOINTS`, ou `null` caso contrário (reaproveita o `resolve()` existente, então um `endpoint:` customizado continua tendo precedência).
- `AdnClient::obterDanfse()`: usa essa URL absoluta quando existe (o Guzzle ignora o `base_uri` nesse caso); sem ela, o caminho nacional continua exatamente como era.

Corrige de uma vez os dois chamadores — `contribuinte()->downloadDanfse()` e `municipio()->downloadDanfse()` — sem mudança de API: quem já informa `codigoMunicipio` no `NfseContext` passa a baixar da prefeitura automaticamente.

## Testes

- `EndpointResolverTest`: URL do município mapeado e `null` para município sem mapeamento.
- `AdnClientTest`: valida a URI efetivamente chamada nos dois cenários (nacional e município).

issue #50


---

## Também nesta PR: retry nas falhas do ambiente nacional

O endpoint do município resolve o 503 só para quem está mapeado (hoje Catanduva/SP). Para todo o resto, cada consulta ou download continuava falhando na primeira tentativa.

O Guzzle 7 já traz `Middleware::retry` com backoff exponencial, então foi só montar o `HandlerStack` com ele (`src/Http/Retry.php`, 44 linhas, sem dependência nova) e usar nos três clients que batem no ambiente nacional — ADN, Sefin e CNC.

- Repete **até 2 vezes** (esperas de 1s e 2s) em **502/503/504** e em queda de conexão.
- Só **GET/HEAD**. `POST` fica de fora de propósito: reenviar `/nfse` ou um evento pode duplicar o documento, já que o servidor pode ter processado antes de falhar.

Testes novos em `tests/Unit/Http/RetryTest.php`: GET 503→200 repete, estoura o limite e propaga, POST não repete. Suíte completa: 218 passando.

### Sobre baixar o DANFSe pelo portal público

Avaliamos usar `https://www.nfse.gov.br/ConsultaPublica/Download/DANFSe?chave=...`, que não exige certificado. **Não é viável:**

- O `chave` daquela URL não é a chave de acesso: é um blob cifrado no servidor (base64 duplo → 56 bytes; 50 chars de chave + padding em bloco de 8). Com a chave em claro o endpoint devolve **404**.
- O único jeito de obter esse token é pela página de consulta pública, que é protegida por **hCaptcha** — automatizar seria burlar o anti-bot.
- O `/DANFSe` da API Sefin Nacional está desativado: a própria spec devolve **501** com _"Este serviço foi movido"_, apontando justamente para o `adn.../danfse` que a lib já usa.

Ou seja, o ADN é mesmo o único caminho oficial, e o retry é o que dá para melhorar nele.
