### PR TITLE
Atualiza schemas NFS-e para o layout 1.01 (pacote de 09/02/2026) e alinha o código

### DIFF
--- a/references/schemas/tiposCnc_v1.00.xsd
+++ b/references/schemas/tiposCnc_v1.00.xsd
@@ -152,4 +152,15 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+  
+  <xs:simpleType name="TVerCNC">
+    <xs:annotation>
+      <xs:documentation>Tipo Versão do CNC - 1.00</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:whiteSpace value="preserve"/>
+      <xs:pattern value="1\.00"/>
+    </xs:restriction>
+  </xs:simpleType>
+
 </xs:schema>

--- a/references/schemas/tiposComplexos_v1.01.xsd
+++ b/references/schemas/tiposComplexos_v1.01.xsd
@@ -125,13 +125,6 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="xOutInf" type="TSDesc2000" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>
-            Uso da Administração Tributária Municipal.
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="valores" type="TCValoresNFSe">
         <xs:annotation>
           <xs:documentation>
@@ -139,6 +132,13 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="xOutInf" type="TSDesc2000" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Uso da Administração Tributária Municipal.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>      
       <xs:element name="IBSCBS" type="TCRTCIBSCBS" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
@@ -229,7 +229,6 @@
         <xs:annotation>
           <xs:documentation>
             Tipo Benefício Municipal (BM):
-
             1) Isenção;
             2) Redução da BC em 'ppBM' %;
             3) Redução da BC em R$ 'vInfoBM';
@@ -269,16 +268,16 @@
       <xs:element name="vTotalRet" type="TSDec15V2" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-            Valor total de retenções = Σ(CP + IRRF + CSLL  + ISSQN* +  (PIS + COFINS)**)
-            vTotalRet (R$) = (vRetCP + vRetIRRF + vRetCSLL) + vISSQN* + (vPIS + vCOFINS)**
+            Valor total das retenções de tributos da NFS-e.
+            Valor total de retenções (R$) = Σ(vRetCP + vRetIRRF+ vRetCSLL + ISSQN*)
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="vLiq" type="TSDec15V2">
         <xs:annotation>
           <xs:documentation>
-            Valor líquido = Valor do serviço - Desconto condicionado - Desconto incondicionado - Valores retidos (CP, IRRF, CSLL)* - Valores, se retidos (ISSQN, PIS, COFINS)**
-            Valor Líquido (R$) = vServ – vDescIncond – vDescCond – (vRetCP + vRetIRRF + vRetCSLL)* – (vISSQN - vPIS + vCOFINS)**
+            Valor líquido da NFS-e.
+            Valor líquido (R$) = Valor do serviço - Desconto condicionado - Desconto incondicionado - Valores retidos
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -969,7 +968,7 @@
             Opção para que o contribuinte optante pelo Simples Nacional ME/EPP (opSimpNac = 3) possa indicar, ao emitir o documento fiscal, em qual regime de apuração os tributos federais e municipal estão inseridos, caso tenha ultrapassado algum sublimite ou limite definido para o Simples Nacional.
             1 – Regime de apuração dos tributos federais e municipal pelo SN;
             2 – Regime de apuração dos tributos federais pelo SN e ISSQN  por fora do SN conforme respectiva legislação municipal do tributo;
-            3 – Regime de apuração dos tributos federais e municipal por fora do SN conforme respectivas legilações federal e municipal de cada tributo;
+            3 – Regime de apuração dos tributos federais e municipal por fora do SN conforme respectivas legislações federal e municipal de cada tributo;
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -984,6 +983,7 @@
             4 - Notário ou Registrador;
             5 - Profissional Autônomo;
             6 - Sociedade de Profissionais;
+            9 - Outros;
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -1024,7 +1024,7 @@
       </xs:choice>
       <xs:element name="CAEPF" type="TSCAEPF" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Número do Cadastro de Atividade Econômica da Pessoa Física (CAEPF) do tomador, intermediário ou fornecedor do serviço.</xs:documentation>
+          <xs:documentation>Número do Cadastro de Atividade Econômica da Pessoa Física (CAEPF)</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="IM" type="TSInscMun" minOccurs="0">
@@ -1301,11 +1301,6 @@
           <xs:documentation>Grupo de informações do DPS relativas à Evento</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="explRod" type="TCExploracaoRodoviaria" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Grupo de informações relativas a pedágio</xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="infoCompl" type="TCInfoCompl" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
@@ -1351,7 +1346,7 @@
           <xs:documentation>Descrição completa do serviço prestado</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="cNBS" type="TSCodNBS">
+      <xs:element name="cNBS" type="TSCodNBS" minOccurs="0">
         <xs:annotation>
           <xs:documentation>Código NBS correspondente ao serviço prestado, seguindo a versão 2.0, conforme Anexo B</xs:documentation>
         </xs:annotation>
@@ -1391,7 +1386,7 @@
             4 - Matriz;
             5 - Filial ou sucursal;
             6 - Outro vínculo;
-            9 - Desconhecido;
+            9 - Desconhecido (tipo não informado na nota de origem);
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -1487,59 +1482,6 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <!--TIPO COMPLEXO PARA INFORMAÇÕES DE PEDÁGIO-->
-  <xs:complexType name="TCExploracaoRodoviaria">
-    <xs:sequence>
-      <xs:element name="categVeic" type="TSCategVeic">
-        <xs:annotation>
-          <xs:documentation>
-            Categorias de veículos para cobrança:
-            00 - Categoria de veículos (tipo não informado na nota de origem)
-            01 - Automóvel, caminhonete e furgão;
-            02 - Caminhão leve, ônibus, caminhão trator e furgão;
-            03 - Automóvel e caminhonete com semireboque;
-            04 - Caminhão, caminhão-trator, caminhão-trator com semi-reboque e ônibus;
-            05 - Automóvel e caminhonete com reboque;
-            06 - Caminhão com reboque;
-            07 - Caminhão trator com semi-reboque;
-            08 - Motocicletas, motonetas e bicicletas motorizadas;
-            09 - Veículo especial;
-            10 - Veículo Isento;
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="nEixos" type="TSNumEixos">
-        <xs:annotation>
-          <xs:documentation>Número de eixos para fins de cobrança</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="rodagem" type="TSRodagem">
-        <xs:annotation>
-          <xs:documentation>Tipo de rodagem</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="sentido" type="TSSentido">
-        <xs:annotation>
-          <xs:documentation>Placa do veículo</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="placa" type="TSPlaca">
-        <xs:annotation>
-          <xs:documentation>Placa do veículo</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="codAcessoPed" type="TSCodAcessoPed">
-        <xs:annotation>
-          <xs:documentation>Código de acesso gerado automaticamente pelo sistema emissor da concessionária.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="codContrato" type="TSCodContrato">
-        <xs:annotation>
-          <xs:documentation>Código de contrato gerado automaticamente pelo sistema nacional no cadastro da concessionária.</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
   <!--TIPO COMPLEXO PARA INFORMAÇÕES DE ATIVIDADE DE EVENTO-->
   <xs:complexType name="TCAtvEvento">
     <xs:sequence>
@@ -1583,8 +1525,8 @@
       <xs:choice minOccurs="1">
         <xs:element name="cObra" type="TSCodObra">
           <xs:annotation>
-            <xs:documentation
-              >Número de identificação da obra.
+            <xs:documentation>
+              Número de identificação da obra.
               Cadastro Nacional de Obras (CNO) ou Cadastro Específico do INSS (CEI).
             </xs:documentation>
           </xs:annotation>
@@ -1827,10 +1769,13 @@
             Identificação da Dedução/Redução:
             1 – Alimentação e bebidas/frigobar;
             2 – Materiais;
+            3 - Produção Externa;
+            4 - Reembolso de despesas;
             5 – Repasse consorciado;
             6 – Repasse plano de saúde;
             7 – Serviços;
             8 – Subempreitada de mão de obra;
+            9 - Profissional parceiro;
             99 – Outras deduções;
           </xs:documentation>
         </xs:annotation>
@@ -2078,60 +2023,92 @@
         <xs:annotation>
           <xs:documentation>
             Código de Situação Tributária do PIS/COFINS (CST):
-            00 - Nenhum;      
+            00 - Nenhum;
             01 - Operação Tributável com Alíquota Básica;
             02 - Operação Tributável com Alíquota Diferenciada;
             03 - Operação Tributável com Alíquota por Unidade de Medida de Produto;
             04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
             05 - Operação Tributável por Substituição Tributária;
             06 - Operação Tributável a Alíquota Zero;
-            07 - Operação Tributável da Contribuição;
+            07 - Operação Isenta da Contribuição;
             08 - Operação sem Incidência da Contribuição;
             09 - Operação com Suspensão da Contribuição;
+            49 - Outras Operações de Saída;
+            50 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+            51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+            52 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita de Exportação;
+            53 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+            54 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+            55 - Operação com Direito a Crédito – Vinculada a Receitas Não Tributadas no Mercado Interno e de Exportação;
+            56 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+            60 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+            61 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+            62 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação;
+            63 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+            64 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+            65 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação;
+            66 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+            67 - Crédito Presumido – Outras Operações;
+            70 - Operação de Aquisição sem Direito a Crédito;
+            71 - Operação de Aquisição com Isenção;
+            72 - Operação de Aquisição com Suspensão;
+            73 - Operação de Aquisição a Alíquota Zero;
+            74 - Operação de Aquisição sem Incidência da Contribuição;
+            75 - Operação de Aquisição por Substituição Tributária;
+            98 - Outras Operações de Entrada;
+            99 - Outras Operações;
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="vBCPisCofins" type="TSDec15V2" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-            Valor da Base de Cálculo do PIS/COFINS (R$).
+            Valor da Base de Cálculo do PIS/COFINS, relativo à apuração própria (R$).
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="pAliqPis" type="TSDec2V2" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-            Valor da Alíquota do PIS (%).
+            Alíquota do PIS, relativa à apuração própria (%).
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="pAliqCofins" type="TSDec2V2" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-            Valor da Alíquota da COFINS (%).
+            Alíquota da COFINS, relativa à apuração própria (%).
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="vPis" type="TSDec15V2" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-            Valor monetário do PIS (R$).
+            Valor do débito de PIS apuração própria (R$).
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="vCofins" type="TSDec15V2" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-            Valor monetário do COFINS (R$).
+            Valor do débito de COFINS apuração própria (R$).
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="tpRetPisCofins" type="TSTipoRetPISCofins" minOccurs="0">
         <xs:annotation>
           <xs:documentation>
-            Tipo de retencao do Pis/Cofins:
-            1 - Retido;
-            2 - Não Retido;
+            Tipo de retenção do PIS/COFINS:
+            0 - PIS/COFINS/CSLL Não Retidos;
+            1 - PIS/COFINS Retidos;
+            2 - PIS/COFINS Não Retidos;
+            3 - PIS/COFINS/CSLL Retidos;
+            4 - PIS/COFINS Retidos, CSLL Não Retido;
+            5 - PIS Retido, COFINS/CSLL Não Retido;
+            6 - COFINS Retido, PIS/CSLL Não Retido;
+            7 - PIS Não Retido, COFINS/CSLL Retidos;
+            8 - PIS/COFINS Não Retidos, CSLL Retido;
+            9 - COFINS Não Retido, PIS/CSLL Retidos;
           </xs:documentation>
         </xs:annotation>
       </xs:element>

--- a/references/schemas/tiposEventos_v1.01.xsd
+++ b/references/schemas/tiposEventos_v1.01.xsd
@@ -15,35 +15,45 @@
     </xs:sequence>
     <xs:attribute name="versao" type="TVerNFSe" use="required"/>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA INFORMAÇÕES DO EVENTO-->
   <xs:complexType name="TCInfEvento">
     <xs:sequence>
-      <xs:element name="verAplic" type="TSVerAplic" minOccurs="0">
+      <xs:element name="verAplic" type="TSVerAplic">
         <xs:annotation>
-          <xs:documentation>Versão do aplicativo que gerou o pedido do evento.</xs:documentation>
+          <xs:documentation>Versão do aplicativo que gerou o evento</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="ambGer" type="TSAmbGeradorEvt">
         <xs:annotation>
-          <xs:documentation>Ambiente gerador do evento</xs:documentation>
+          <xs:documentation>
+            Ambiente gerador do evento:
+            1 - Sistema próprio do município;
+            2 - Sefin Nacional NFS-e;
+            3 - ADN NFS-e;
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="nSeqEvento" type="TSNum3Dig">
         <xs:annotation>
-          <xs:documentation>Sequencial do evento para o mesmo tipo de evento. Para maioria dos eventos nSeqEvento=1. Nos casos em que possa existir mais de um evento do mesmo tipo o ambiente gerador deverá numerar de forma sequencial.</xs:documentation>
+          <xs:documentation>
+            Número sequencial do evento para o mesmo tipo de evento.
+            Para os eventos que ocorrem somente uma vez, como é o caso do cancelamento, o nSeqEvento = 001.
+            Para os eventos que possam existir mais de um evento do mesmo tipo o ambiente gerador deverá numerar de forma sequencial.
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="dhProc" type="TSDateTimeUTC">
         <xs:annotation>
           <xs:documentation>
             Data/Hora do registro do evento.
-            Data e hora no formato UTC (Universal Coordinated Time): AAAA-MM-DDThh:mm:ssTZD"
+            Data e hora no formato UTC (Universal Coordinated Time): AAAA-MM-DDThh:mm:ssTZD
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="nDFe" type="TSNumDFe">
+      <xs:element name="nDFSe" type="TSNumDFe">
         <xs:annotation>
-          <xs:documentation>Ambiente gerador do evento</xs:documentation>
+          <xs:documentation>Número sequencial do documento gerado por ambiente gerador de DFSe do município</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="pedRegEvento" type="TCPedRegEvt">
@@ -54,6 +64,7 @@
     </xs:sequence>
     <xs:attribute name="Id" type="TSIdEvento" use="required"/>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PEDIDO DE REGISTRO DE EVENTO -->
   <xs:complexType name="TCPedRegEvt">
     <xs:sequence>
@@ -62,24 +73,28 @@
     </xs:sequence>
     <xs:attribute name="versao" type="TVerNFSe" use="required"/>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA AS INFORMAÇÕES DO PEDIDO DE REGISTRO DE EVENTO -->
   <xs:complexType name="TCInfPedReg">
     <xs:sequence>
       <xs:element name="tpAmb" type="TSTipoAmbiente">
         <xs:annotation>
-          <xs:documentation>Identificação do Ambiente: 1 - Produção; 2 - Homologação</xs:documentation>
+          <xs:documentation>
+            Tipo de ambiente:
+            1 - Produção;
+            2 - Homologação;
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="verAplic" type="TSVerAplic">
         <xs:annotation>
-          <xs:documentation>Versão do aplicativo que gerou o pedido de registro de evento.</xs:documentation>
+          <xs:documentation>Versão do aplicativo que gerou o pedido de registro de evento</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="dhEvento" type="TSDateTimeUTC">
         <xs:annotation>
           <xs:documentation>
-            Data e hora do evento no formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal Coordinated Time, onde TZD pode ser -02:00 (Fernando de Noronha), -03:00 (Brasília) ou -04:00 (Manaus), no horário de verão serão -01:00, -02:00 e -03:00.
-            Ex.: 2010-08-19T13:00:15-03:00.
+            Data e hora do evento no formato AAAA-MM-DDThh:mm:ssTZD (UTC - Universal Coordinated Time, onde TZD pode ser -02:00 (Fernando de Noronha), -03:00 (Brasília) ou -04:00 (Manaus), no horário de verão serão -01:00, -02:00 e -03:00. Ex.: 2010-08-19T13:00:15-03:00.
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -89,27 +104,26 @@
         </xs:annotation>
         <xs:element name="CNPJAutor" type="TSCNPJ">
           <xs:annotation>
-            <xs:documentation>CNPJ do autor do evento.</xs:documentation>
+            <xs:documentation>
+              Número de inscrição federal (CNPJ) do autor do evento.
+              CNPJ do autor do evento (parte interessada ou pessoa que figure na NFS-e.
+              O autor do evento não é o procurador)
+            </xs:documentation>
           </xs:annotation>
         </xs:element>
         <xs:element name="CPFAutor" type="TSCPF">
           <xs:annotation>
-            <xs:documentation>CPF do autor do evento.</xs:documentation>
+            <xs:documentation>
+              Número de inscrição federal (CPF) do autor do evento.
+              CPF do autor do evento (parte interessada ou pessoa que figure na NFS-e como prestador, tomador, intermediário.
+              O autor do evento poderá ser o procurador)
+            </xs:documentation>
           </xs:annotation>
         </xs:element>
       </xs:choice>
       <xs:element name="chNFSe" type="TSChaveNFSe">
         <xs:annotation>
-          <xs:documentation>Chave de Acesso da NFS-e vinculada ao Evento</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="nPedRegEvento" type="TSNum3Dig">
-        <xs:annotation>
-          <xs:documentation>
-            Número do pedido do registro de evento para o mesmo tipo de evento.
-            Para os eventos que ocorrem somente uma vez, como é o caso do cancelamento, o nPedRegEvento deve ser igual a 1.
-            Os eventos que podem ocorrer mais de uma vez devem ter o nPedRegEvento único.
-          </xs:documentation>
+          <xs:documentation>Identificador da NFS-e à qual o evento será vinculado</xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:choice>
@@ -138,6 +152,7 @@
             <xs:documentation>Cancelamento de NFS-e Indeferido por Análise Fiscal</xs:documentation>
           </xs:annotation>
         </xs:element>
+
         <xs:element name="e202201" type="TE202201">
           <xs:annotation>
             <xs:documentation>Confirmação do Prestador</xs:documentation>
@@ -178,6 +193,7 @@
             <xs:documentation>Anulação da Rejeição</xs:documentation>
           </xs:annotation>
         </xs:element>
+
         <xs:element name="e305101" type="TE305101">
           <xs:annotation>
             <xs:documentation>Cancelamento de NFS-e por Ofício</xs:documentation>
@@ -195,8 +211,9 @@
         </xs:element>
       </xs:choice>
     </xs:sequence>
-    <xs:attribute name="Id" type="TSIdPedRefEvt" use="required"/>
+    <xs:attribute name="Id" type="TSIdPedRegEvt" use="required"/>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CANCELAMENTO-->
   <xs:complexType name="TE101101">
     <xs:sequence>
@@ -215,7 +232,12 @@
       </xs:element>
       <xs:element name="cMotivo" type="TSCodJustCanc">
         <xs:annotation>
-          <xs:documentation>Código de justificativa de cancelamento</xs:documentation>
+          <xs:documentation>
+            Código de justificativa de cancelamento:
+            1 - Erro na Emissão;
+            2 - Serviço não Prestado;
+            9 - Outros;
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="xMotivo" type="TSMotivo">
@@ -225,6 +247,7 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CANCELAMENTO POR SUBSTITUIÇÃO-->
   <xs:complexType name="TE105102">
     <xs:sequence>
@@ -237,27 +260,40 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Cancelamento de NFS-e por Substituicao"/>
+            <xs:enumeration value="Cancelamento de NFS-e por Substituição"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
       <xs:element name="cMotivo" type="TSCodJustSubst">
         <xs:annotation>
-          <xs:documentation>Código de justificativa de cancelamento substituição</xs:documentation>
+          <xs:documentation>
+            Código de justificativa de cancelamento substituição:
+            01 - Desenquadramento de NFS-e do Simples Nacional;
+            02 - Enquadramento de NFS-e no Simples Nacional;
+            03 - Inclusão Retroativa de Imunidade/Isenção para NFS-e;
+            04 - Exclusão Retroativa de Imunidade/Isenção para NFS-e;
+            05 - Rejeição de NFS-e pelo tomador ou pelo intermediário se responsável pelo recolhimento do tributo;
+            99 - Outros;
+            Obtido do campo da DPS "DPS/infDPS/subst/cMotivo"
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="xMotivo" type="TSMotivo" minOccurs="0">
         <xs:annotation>
-          <xs:documentation>Descrição para explicitar o motivo indicado neste evento</xs:documentation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento.
+            Obtido do campo da DPS "DPS/infDPS/subst/xMotivo".
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="chSubstituta" type="TSChaveNFSe">
         <xs:annotation>
-          <xs:documentation>Chave de Acesso da NFS-e substituta.</xs:documentation>
+          <xs:documentation>Chave de Acesso da NFS-e substituta</xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE SOLICITAÇÃO DE ANÁLISE FISCAL PARA CANCELAMENTO DE NFS-E-->
   <xs:complexType name="TE101103">
     <xs:sequence>
@@ -270,22 +306,30 @@
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Solicitacao de Analise Fiscal para Cancelamento de NFS-e"/>
+            <xs:enumeration value="Solicitação de Análise Fiscal para Cancelamento de NFS-e"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
       <xs:element name="cMotivo" type="TSCodJustAnaliseFiscalCanc">
         <xs:annotation>
-          <xs:documentation>Código do motivo da solicitação de análise fiscal para cancelamento de NFS-e:</xs:documentation>
+          <xs:documentation>
+            Código do motivo da solicitação de análise fiscal para cancelamento de NFS-e:
+            1 - Erro na Emissão;
+            2 - Serviço não Prestado;
+            9 - Outros;
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="xMotivo" type="TSMotivo">
         <xs:annotation>
-          <xs:documentation>Descrição para explicitar o motivo indicado neste evento</xs:documentation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CANCELAMENTO DE NFS-E DEFERIDO POR ANÁLISE FISCAL-->
   <xs:complexType name="TE105104">
     <xs:sequence>
@@ -305,7 +349,7 @@
       <xs:element name="CPFAgTrib" type="TSCPF">
         <xs:annotation>
           <xs:documentation>
-            CPF do agente da administração tributária municipal que efetuou o deferimento da  solicitação de análise fiscal para cancelamento de NFS-e.
+            CPF do agente da administração tributária municipal que efetuou o deferimento da solicitação de análise fiscal para cancelamento de NFS-e.
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -333,6 +377,7 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CANCELAMENTO DE NFS-E INDEFERIDO POR ANÁLISE FISCAL-->
   <xs:complexType name="TE105105">
     <xs:sequence>
@@ -374,186 +419,254 @@
       </xs:element>
       <xs:element name="xMotivo" type="TSMotivo">
         <xs:annotation>
-          <xs:documentation>Descrição para explicitar o motivo indicado neste evento</xs:documentation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CONFIRMAÇÃO DO PRESTADOR-->
   <xs:complexType name="TE202201">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Confirmação do Prestador".
+            Descrição do evento: "Manifestação de NFS-e - Confirmação do Prestador".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Confirmação do Prestador"/>
+            <xs:enumeration value="Manifestação de NFS-e - Confirmação do Prestador"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CONFIRMAÇÃO DO TOMADOR-->
   <xs:complexType name="TE203202">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Confirmação do Tomador".
+            Descrição do evento: "Manifestação de NFS-e - Confirmação do Tomador".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Confirmação do Tomador"/>
+            <xs:enumeration value="Manifestação de NFS-e - Confirmação do Tomador"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CONFIRMAÇÃO DO INTERMEDIÁRIO-->
   <xs:complexType name="TE204203">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Confirmação do Intermediário".
+            Descrição do evento: "Manifestação de NFS-e - Confirmação do Intermediário".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Confirmação do Intermediário"/>
+            <xs:enumeration value="Manifestação de NFS-e - Confirmação do Intermediário"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE CONFIRMAÇÃO TÁCITA-->
   <xs:complexType name="TE205204">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Confirmação Tácita".
+            Descrição do evento: "Manifestação de NFS-e - Confirmação Tácita".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Confirmação Tácita"/>
+            <xs:enumeration value="Manifestação de NFS-e - Confirmação Tácita"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE REJEIÇÃO DO PRESTADOR-->
   <xs:complexType name="TE202205">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Rejeição do Prestador".
+            Descrição do evento: "Manifestação de NFS-e - Rejeição do Prestador".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Rejeição do Prestador"/>
+            <xs:enumeration value="Manifestação de NFS-e - Rejeição do Prestador"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="infRej" type="TCInfoEventoRejeicao">
+      <xs:element name="cMotivo" type="TSCodMotivoRejeicao">
         <xs:annotation>
           <xs:documentation>
+            Motivo da Rejeição da NFS-e:
+            1 - NFS-e em duplicidade;
+            2 - NFS-e já emitida pelo tomador;
+            3 - Não ocorrência do fato gerador;
+            4 - Erro quanto a responsabilidade tributária;
+            5 - Erro quanto ao valor do serviço, valor das deduções ou serviço prestado ou data do fato gerador;
+            9 - Outros;
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xMotivo" type="TSMotivo" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento
           </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE REJEIÇÃO DO TOMADOR-->
   <xs:complexType name="TE203206">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Rejeição do Tomador".
+            Descrição do evento: "Manifestação de NFS-e - Rejeição do Tomador".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Rejeição do Tomador"/>
+            <xs:enumeration value="Manifestação de NFS-e - Rejeição do Tomador"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="infRej" type="TCInfoEventoRejeicao">
+      <xs:element name="cMotivo" type="TSCodMotivoRejeicao">
         <xs:annotation>
           <xs:documentation>
+            Motivo da Rejeição da NFS-e:
+            1 - NFS-e em duplicidade;
+            2 - NFS-e já emitida pelo tomador;
+            3 - Não ocorrência do fato gerador;
+            4 - Erro quanto a responsabilidade tributária;
+            5 - Erro quanto ao valor do serviço, valor das deduções ou serviço prestado ou data do fato gerador;
+            9 - Outros;
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xMotivo" type="TSMotivo" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento
           </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE REJEIÇÃO DO INTERMEDIÁRIO-->
   <xs:complexType name="TE204207">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Rejeição do Intermediário".
+            Descrição do evento: "Manifestação de NFS-e - Rejeição do Intermediário".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Rejeição do Intermediário"/>
+            <xs:enumeration value="Manifestação de NFS-e - Rejeição do Intermediário"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="infRej" type="TCInfoEventoRejeicao">
+      <xs:element name="cMotivo" type="TSCodMotivoRejeicao">
         <xs:annotation>
           <xs:documentation>
+            Motivo da Rejeição da NFS-e:
+            1 - NFS-e em duplicidade;
+            2 - NFS-e já emitida pelo tomador;
+            3 - Não ocorrência do fato gerador;
+            4 - Erro quanto a responsabilidade tributária;
+            5 - Erro quanto ao valor do serviço, valor das deduções ou serviço prestado ou data do fato gerador;
+            9 - Outros;
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xMotivo" type="TSMotivo" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento
           </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE ANULAÇÃO DE REJEIÇÃO-->
   <xs:complexType name="TE205208">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Anulação da Rejeição".
+            Descrição do evento: "Manifestação de NFS-e - Anulação da Rejeição".
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
           <xs:restriction base="xs:string">
             <xs:whiteSpace value="preserve"/>
-            <xs:enumeration value="Anulação da Rejeição"/>
+            <xs:enumeration value="Manifestação de NFS-e - Anulação da Rejeição"/>
           </xs:restriction>
         </xs:simpleType>
       </xs:element>
-      <xs:element name="infAnRej" type="TCInfoEventoAnulacaoRejeicao">
+      <xs:element name="CPFAgTrib" type="TSCPF">
         <xs:annotation>
           <xs:documentation>
+            CPF do agente da administração tributária municipal que efetuou o anulação da manifestação de rejeição da NFS-e
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="idEvManifRej" type="TSIdNumEvento">
+        <xs:annotation>
+          <xs:documentation>
+            Referência ao "id" do Evento de Manifestação de NFS-e - Rejeição, que originou o presente evento de anulação
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="xMotivo" type="TSMotivo">
+        <xs:annotation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento
           </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <!--TIPO COMPLEXO PARA O EVENTO DE CANCELAMENTO POR OFÍCIO DA NFS-E--> 
+
+  <!--TIPO COMPLEXO PARA O EVENTO DE CANCELAMENTO POR OFÍCIO DA NFS-E-->
   <xs:complexType name="TE305101">
     <xs:sequence>
       <xs:element name="xDesc">
         <xs:annotation>
           <xs:documentation>
-            Descrição do evento: "Cancelamento de NFS-e por Ofício".
+            Descrição do evento: "Cancelamento de NFS-e por Ofício"
           </xs:documentation>
         </xs:annotation>
         <xs:simpleType>
@@ -566,27 +679,28 @@
       <xs:element name="CPFAgTrib" type="TSCPF">
         <xs:annotation>
           <xs:documentation>
-            CPF do agente da administração tributária municipal que efetuou o cancelamento por ofício de NFS-e.
+            CPF do agente da administração tributária municipal que efetuou o cancelamento por ofício de NFS-e
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="nProcAdm" type="TSNumProcAdmAnaliseFiscalCanc">
         <xs:annotation>
           <xs:documentation>
-            Número do processo administrativo municipal vinculado ao cancelamento de NFS-e por ofício.
+            Número do processo administrativo municipal vinculado ao cancelamento de NFS-e por ofício
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="xProcAdm" type="TSMotivo">
         <xs:annotation>
           <xs:documentation>
-            Descrição para explicitar o motivo indicado neste evento.
+            Descrição para explicitar o motivo do processo administrativo municipal indicado neste evento
           </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
-  <!--TIPO COMPLEXO PARA O EVENTO DE BLOQUEIO POR OFÍCIO DA NFS-E--> 
+
+  <!--TIPO COMPLEXO PARA O EVENTO DE BLOQUEIO POR OFÍCIO DA NFS-E-->
   <xs:complexType name="TE305102">
     <xs:sequence>
       <xs:element name="xDesc">
@@ -605,22 +719,32 @@
       <xs:element name="CPFAgTrib" type="TSCPF">
         <xs:annotation>
           <xs:documentation>
-            CPF do agente da administração tributária municipal que efetuou o cancelamento por ofício de NFS-e.
+            CPF do agente da administração tributária municipal que efetuou o bloqueio de NFS-e por ofício
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="codEvento" type="TSCodigoEventoNFSe">
+        <xs:annotation>
+          <xs:documentation>
+            Eventos que podem ser escolhidos pelo município emissor para serem rejeitados após emissão e vinculação do evento de bloqueio por ofício em uma NFS-e:
+            e101101 - Cancelamento de NFS-e;
+            e105102 - Cancelamento de NFS-e por Substituição;
+            e105104 - Cancelamento de NFS-e Deferido por Análise Fiscal;
+            e105105 - Cancelamento de NFS-e Indeferido por Análise Fiscal;
+            e305101 - Cancelamento de NFS-e por Ofício;
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="xMotivo" type="TSMotivo">
         <xs:annotation>
-          <xs:documentation>Descrição para explicitar o motivo indicado neste evento</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="codEvento" type="TSCodigoEventoNFSe">
-        <xs:annotation>
-          <xs:documentation>Descrição para explicitar o motivo indicado neste evento</xs:documentation>
+          <xs:documentation>
+            Descrição para explicitar o motivo indicado neste evento
+          </xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
   <!--TIPO COMPLEXO PARA O EVENTO DE DESBLOQUEIO POR OFÍCIO DA NFS-E-->
   <xs:complexType name="TE305103">
     <xs:sequence>
@@ -640,74 +764,15 @@
       <xs:element name="CPFAgTrib" type="TSCPF">
         <xs:annotation>
           <xs:documentation>
-            CPF do agente da administração tributária municipal que efetuou o cancelamento por ofício de NFS-e.
+            CPF do agente da administração tributária municipal que efetuou o desbloqueio de NFS-e por ofício
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="idBloqOfic" type="TSIdNumEvento">
         <xs:annotation>
           <xs:documentation>
-            Referência ao Id da "Manifestação de rejeição da NFS-e" que originou o presente evento de anulação.
+            Referência ao "id" do "Bloqueio de ofício" que originou o presente evento de desbloqueio
           </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-  <!--TIPO COMPLEXO LISTA DE EVENTOS--> 
-  <xs:complexType name="TCListaEventos">
-    <xs:sequence>
-      <xs:element name="codEvento" type="TSCodigoEventoNFSe" maxOccurs="9">
-        <xs:annotation>
-          <xs:documentation>
-            Grupo de informações de documento utilizado para Dedução/Redução do valor do serviço
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-  <!--TIPO COMPLEXO INFORMAÇÕES DO EVENTO DE REJEIÇÃO DA NFS-E-->
-  <xs:complexType name="TCInfoEventoRejeicao">
-    <xs:sequence>
-      <xs:element name="cMotivo" type="TSCodMotivoRejeicao">
-        <xs:annotation>
-          <xs:documentation>
-            Motivo da Rejeição da NFS-e:
-            1 - NFS-e em duplicidade;
-            2 - NFS-e já emitida pelo tomador;
-            3 - Não ocorrência do fato gerador;
-            4 - Erro quanto a responsabilidade tributária;
-            5 - Erro quanto ao valor do serviço, valor das deduções ou serviço prestado ou data do fato gerador;
-            9 - Outros;
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="xMotivo" type="TSMotivo" minOccurs="0">
-        <xs:annotation>
-          <xs:documentation>Descrição para explicitar o motivo indicado neste evento</xs:documentation>
-        </xs:annotation>
-      </xs:element>
-    </xs:sequence>
-  </xs:complexType>
-  <!--TIPO COMPLEXO INFORMAÇÕES DO EVENTO DE ANULAÇÃO DE REJEIÇÃO DA NFS-E-->
-  <xs:complexType name="TCInfoEventoAnulacaoRejeicao">
-    <xs:sequence>
-      <xs:element name="CPFAgTrib" type="TSCPF">
-        <xs:annotation>
-          <xs:documentation>
-            CPF do agente da administração tributária municipal que efetuou o anulação da manifestação de rejeição da NFS-e.
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="idEvManifRej" type="TSIdNumEvento">
-        <xs:annotation>
-          <xs:documentation>
-            Referência ao Id da "Manifestação de rejeição da NFS-e" que originou o presente evento de anulação.
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
-      <xs:element name="xMotivo" type="TSMotivo">
-        <xs:annotation>
-          <xs:documentation>Descrição para explicitar o motivo da anluação</xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>

--- a/references/schemas/tiposSimples_v1.01.xsd
+++ b/references/schemas/tiposSimples_v1.01.xsd
@@ -2,20 +2,12 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.sped.fazenda.gov.br/nfse" xmlns="http://www.sped.fazenda.gov.br/nfse" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:simpleType name="TVerNFSe">
     <xs:annotation>
-      <xs:documentation>Tipo Versão da NF-e - 1.01</xs:documentation>
+      <xs:documentation>Tipo Versão da NF-e - 1.00|1.01</xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
+      <xs:maxLength value="4"/>
       <xs:whiteSpace value="preserve"/>
-      <xs:pattern value="1\.01"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="TVerCNC">
-    <xs:annotation>
-      <xs:documentation>Tipo Versão do CNC - 1.00</xs:documentation>
-    </xs:annotation>
-    <xs:restriction base="xs:string">
-      <xs:whiteSpace value="preserve"/>
-      <xs:pattern value="1\.00"/>
+      <xs:pattern value="1\.00|1\.01"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSString">
@@ -65,7 +57,9 @@
   <xs:simpleType name="TSTipoAmbiente">
     <xs:annotation>
       <xs:documentation>
-        Tipos de ambiente do Sistema Nacional NFS-e: 1 - Produção; 2 - Homologação;
+        Tipos de ambiente do Sistema Nacional NFS-e: 
+        1 - Produção; 
+        2 - Homologação;
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -164,7 +158,7 @@
   <xs:simpleType name="TSSerieDPS">
     <xs:restriction base="xs:string">
       <xs:maxLength value="5"/>
-      <xs:pattern value="^(?!0{1,5}$)\d{1,5}$"/>
+      <xs:pattern value="^0{0,4}\d{1,5}$"/>
       <xs:whiteSpace value="preserve"/>
     </xs:restriction>
   </xs:simpleType>
@@ -621,7 +615,7 @@
         4 - Matriz;
         5 - Filial ou sucursal;
         6 - Outro vínculo;
-        9 - Desconhecido;
+        9 - Desconhecido (tipo não informado na nota de origem);
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -926,10 +920,13 @@
 	Identificação da Dedução/Redução:
         1 – Alimentação e bebidas/frigobar;
         2 – Materiais;
+        3 - Produção Externa;
+        4 - Reembolso de despesas;
         5 – Repasse consorciado;
         6 – Repasse plano de saúde;
         7 – Serviços;
         8 – Subempreitada de mão de obra;
+        9 - Profissional parceiro;
         99 – Outras deduções;
       </xs:documentation>
     </xs:annotation>
@@ -937,10 +934,13 @@
       <xs:whiteSpace value="preserve"/>
       <xs:enumeration value="1"/>
       <xs:enumeration value="2"/>
+      <xs:enumeration value="3"/>
+      <xs:enumeration value="4"/>
       <xs:enumeration value="5"/>
       <xs:enumeration value="6"/>
       <xs:enumeration value="7"/>
       <xs:enumeration value="8"/>
+      <xs:enumeration value="9"/>
       <xs:enumeration value="99"/>
     </xs:restriction>
   </xs:simpleType>
@@ -1015,7 +1015,7 @@
         Opção para que o contribuinte optante pelo Simples Nacional ME/EPP (opSimpNac = 3) possa indicar, ao emitir o documento fiscal, em qual regime de apuração os tributos federais e municipal estão inseridos, caso tenha ultrapassado algum sublimite ou limite definido para o Simples Nacional.
         1 – Regime de apuração dos tributos federais e municipal pelo SN;
         2 – Regime de apuração dos tributos federais pelo SN e ISSQN  por fora do SN conforme respectiva legislação municipal do tributo;
-        3 – Regime de apuração dos tributos federais e municipal por fora do SN conforme respectivas legilações federal e municipal de cada tributo;
+        3 – Regime de apuração dos tributos federais e municipal por fora do SN conforme respectivas legislações federal e municipal de cada tributo;
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1050,6 +1050,7 @@
         4 - Notário ou Registrador;
         5 - Profissional Autônomo;
         6 - Sociedade de Profissionais;
+        9 - Outros;
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1061,6 +1062,7 @@
       <xs:enumeration value="4"/>
       <xs:enumeration value="5"/>
       <xs:enumeration value="6"/>
+      <xs:enumeration value="9"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSTribISSQN">
@@ -1145,9 +1147,33 @@
         04 - Operação Tributável monofásica - Revenda a Alíquota Zero;
         05 - Operação Tributável por Substituição Tributária;
         06 - Operação Tributável a Alíquota Zero;
-        07 - Operação Tributável da Contribuição;
+        07 - Operação Isenta da Contribuição;
         08 - Operação sem Incidência da Contribuição;
         09 - Operação com Suspensão da Contribuição;
+        49 - Outras Operações de Saída;
+        50 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+        51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+        52 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita de Exportação;
+        53 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+        54 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+        55 - Operação com Direito a Crédito – Vinculada a Receitas Não Tributadas no Mercado Interno e de Exportação;
+        56 - Operação com Direito a Crédito – Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+        60 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno;
+        61 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno;
+        62 - Crédito Presumido – Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação;
+        63 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno;
+        64 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação;
+        65 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação;
+        66 - Crédito Presumido – Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno e de Exportação;
+        67 - Crédito Presumido – Outras Operações;
+        70 - Operação de Aquisição sem Direito a Crédito;
+        71 - Operação de Aquisição com Isenção;
+        72 - Operação de Aquisição com Suspensão;
+        73 - Operação de Aquisição a Alíquota Zero;
+        74 - Operação de Aquisição sem Incidência da Contribuição;
+        75 - Operação de Aquisição por Substituição Tributária;
+        98 - Outras Operações de Entrada;
+        99 - Outras Operações;
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1162,6 +1188,30 @@
       <xs:enumeration value="07"/>
       <xs:enumeration value="08"/>
       <xs:enumeration value="09"/>
+      <xs:enumeration value="49"/>
+      <xs:enumeration value="50"/>
+      <xs:enumeration value="51"/>
+      <xs:enumeration value="52"/>
+      <xs:enumeration value="53"/>
+      <xs:enumeration value="54"/>
+      <xs:enumeration value="55"/>
+      <xs:enumeration value="56"/>
+      <xs:enumeration value="60"/>
+      <xs:enumeration value="61"/>
+      <xs:enumeration value="62"/>
+      <xs:enumeration value="63"/>
+      <xs:enumeration value="64"/>
+      <xs:enumeration value="65"/>
+      <xs:enumeration value="66"/>
+      <xs:enumeration value="67"/>
+      <xs:enumeration value="70"/>
+      <xs:enumeration value="71"/>
+      <xs:enumeration value="72"/>
+      <xs:enumeration value="73"/>
+      <xs:enumeration value="74"/>
+      <xs:enumeration value="75"/>
+      <xs:enumeration value="98"/>
+      <xs:enumeration value="99"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSOpConsumServ">
@@ -1182,14 +1232,30 @@
     <xs:annotation>
       <xs:documentation>
         Tipo de retencao do Pis/Cofins:
-        1 - Retido;
-        2 - Não Retido;
+	0 - PIS/COFINS/CSLL Não Retidos;
+	1 - PIS/COFINS Retidos;
+	2 - PIS/COFINS Não Retidos;
+	3 - PIS/COFINS/CSLL Retidos;
+	4 - PIS/COFINS Retidos, CSLL Não Retido;
+	5 - PIS Retido, COFINS/CSLL Não Retido;
+	6 - COFINS Retido, PIS/CSLL Não Retido;
+	7 - PIS Não Retido, COFINS/CSLL Retidos;
+	8 - PIS/COFINS Não Retidos, CSLL Retido;
+	9 - COFINS Não Retido, PIS/CSLL Retidos;
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
+      <xs:enumeration value="0"/>
       <xs:enumeration value="1"/>
       <xs:enumeration value="2"/>
+      <xs:enumeration value="3"/>
+      <xs:enumeration value="4"/>
+      <xs:enumeration value="5"/>
+      <xs:enumeration value="6"/>
+      <xs:enumeration value="7"/>
+      <xs:enumeration value="8"/>
+      <xs:enumeration value="9"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSTipoIndTotTrib">
@@ -1228,7 +1294,6 @@
       <xs:documentation>
         Situações possíveis:
         100 - NFS-e Gerada;
-        101 - NFS-e de Substituição Gerada;
         102 - NFS-e de Decisão Judicial;
         103 - NFS-e Avulsa;
         107 - NFS-e MEI;
@@ -1237,7 +1302,6 @@
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
       <xs:enumeration value="100"/>
-      <xs:enumeration value="101"/>
       <xs:enumeration value="102"/>
       <xs:enumeration value="103"/>
       <xs:enumeration value="107"/>
@@ -1441,7 +1505,7 @@
       <xs:pattern value="[0-9]{15}"/>
     </xs:restriction>
   </xs:simpleType>
-  <xs:simpleType name="TSIdPedRefEvt">
+  <xs:simpleType name="TSIdPedRegEvt">
     <xs:annotation>
       <xs:documentation>
         O identificador do pedido de registro do evento é formado conforme a concatenação dos seguintes campos:
@@ -1450,14 +1514,14 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:whiteSpace value="preserve"/>
-      <xs:maxLength value="62"/>
-      <xs:pattern value="PRE[0-9]{59}"/>
+      <xs:maxLength value="59"/>
+      <xs:pattern value="PRE[0-9]{56}"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSIdEvento">
     <xs:annotation>
       <xs:documentation>
-		  Identificador do evento: "EVT" + Chave de acesso(50) Tipo do evento (6) + Pedido de Registro do Evento(3) (nPedRegEvento)
+	Identificador do evento: "EVT" + Chave de acesso(50) Tipo do evento (6) + Pedido de Registro do Evento(3) (nPedRegEvento)
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1469,7 +1533,7 @@
   <xs:simpleType name="TSCodigoEventoNFSe">
     <xs:annotation>
       <xs:documentation>
-		  Código de evento da NFS-e
+	Código de evento da NFS-e
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1478,14 +1542,12 @@
       <xs:enumeration value="e105104"/>
       <xs:enumeration value="e105105"/>
       <xs:enumeration value="e305101"/>
-      <xs:enumeration value="e907202"/>
-      <xs:enumeration value="e967203"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="TSIdNumEvento">
     <xs:annotation>
       <xs:documentation>
-		  Referência ao Id "Manifestação de rejeição da NFS-e" que originou o presente evento de anulação.
+	Referência ao Id "Manifestação de rejeição da NFS-e" que originou o presente evento de anulação.
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1496,7 +1558,7 @@
   <xs:simpleType name="TSNumDFe">
     <xs:annotation>
       <xs:documentation>
-		  Número sequencial do documento gerado por ambiente gerador de DFe do município.
+	Número sequencial do documento gerado por ambiente gerador de DFe do município.
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1506,7 +1568,9 @@
   </xs:simpleType>
   <xs:simpleType name="TSSituacaoCadastroContribuinte">
     <xs:annotation>
-      <xs:documentation>Identificação da situação do cadastro do contribuinte</xs:documentation>
+      <xs:documentation>
+        Identificação da situação do cadastro do contribuinte
+      </xs:documentation>
     </xs:annotation>
     <xs:restriction base="TSString">
       <xs:minLength value="1"/>
@@ -1515,7 +1579,9 @@
   </xs:simpleType>
   <xs:simpleType name="TSMotivoSituacaoCadastroContribuinte">
     <xs:annotation>
-      <xs:documentation>Motivo pelo qual o contribuinte se enquadra na situação informada</xs:documentation>
+      <xs:documentation>
+        Motivo pelo qual o contribuinte se enquadra na situação informada
+      </xs:documentation>
     </xs:annotation>
     <xs:restriction base="TSString">
       <xs:minLength value="1"/>
@@ -1524,7 +1590,7 @@
   <xs:simpleType name="TSSituacaoEmissaoNFSE">
     <xs:annotation>
       <xs:documentation>
-		  Situação Emissão NFS-e:
+	Situação Emissão NFS-e:
         0 - Não Habilitado;
         1 - Habilitado;
       </xs:documentation>
@@ -1538,7 +1604,7 @@
   <xs:simpleType name="TSCategoriaServico">
     <xs:annotation>
       <xs:documentation>
-		  Categorias do serviço:
+	Categorias do serviço:
         1 - Locação;
         2 - Sublocação;
         3 - Arrendamento;
@@ -1579,7 +1645,9 @@
   </xs:simpleType>
   <xs:simpleType name="TSExtensaoTotal">
     <xs:annotation>
-      <xs:documentation>Extensão total da ferrovia, rodovia, cabos, dutos ou condutos</xs:documentation>
+      <xs:documentation>
+        Extensão total da ferrovia, rodovia, cabos, dutos ou condutos
+      </xs:documentation>
     </xs:annotation>
     <xs:restriction base="TSString">
       <xs:minLength value="1"/>

--- a/src/Dto/Nfse/InfEventoData.php
+++ b/src/Dto/Nfse/InfEventoData.php
@@ -22,8 +22,8 @@ class InfEventoData extends Dto
     #[MapFrom('dhProc')]
     public ?string $dataHoraProcessamento = null;
 
-    #[MapFrom('nDFe')]
-    public ?string $numeroDfe = null;
+    #[MapFrom('nDFSe')]
+    public ?string $numeroDfse = null;
 
     #[MapFrom('pedRegEvento')]
     public ?PedRegEventoData $pedRegEvento = null;

--- a/src/Dto/Nfse/InfPedRegData.php
+++ b/src/Dto/Nfse/InfPedRegData.php
@@ -92,13 +92,4 @@ class InfPedRegData extends Dto
 
     #[MapFrom('e305103')]
     public ?DesbloqueioPorOficioData $e305103 = null;
-
-    /**
-     * === RESERVADOS PELO SCHEMA ===
-     */
-    #[MapFrom('e907202')]
-    public mixed $e907202 = null;
-
-    #[MapFrom('e967203')]
-    public mixed $e967203 = null;
 }

--- a/src/Enums/CodigoStatus.php
+++ b/src/Enums/CodigoStatus.php
@@ -15,11 +15,6 @@ enum CodigoStatus: int
     case NfseGerada = 100;
 
     /**
-     * NFS-e de Substituição Gerada
-     */
-    case NfseSubstituicaoGerada = 101;
-
-    /**
      * NFS-e de Decisão Judicial
      */
     case NfseDecisaoJudicial = 102;
@@ -41,7 +36,6 @@ enum CodigoStatus: int
     {
         return match ($this) {
             self::NfseGerada => 'NFS-e Gerada',
-            self::NfseSubstituicaoGerada => 'NFS-e de Substituição Gerada',
             self::NfseDecisaoJudicial => 'NFS-e de Decisão Judicial',
             self::NfseAvulsa => 'NFS-e Avulsa',
             self::NfseMei => 'NFS-e MEI',

--- a/src/Enums/RegimeEspecialTributacao.php
+++ b/src/Enums/RegimeEspecialTributacao.php
@@ -44,10 +44,11 @@ enum RegimeEspecialTributacao: string
      */
     case SociedadeDeProfissionais = '6';
 
-    case NaoInformadoIdentificado7 = '7';
-    case NaoInformadoIdentificado8 = '8';
-    case NaoInformadoIdentificado9 = '9';
-    case NaoInformadoIdentificado10 = '10';
+    /**
+     * Outros
+     */
+    case Outros = '9';
+
 
     /**
      * Get description for the enum case
@@ -62,10 +63,7 @@ enum RegimeEspecialTributacao: string
             self::NotarioOuRegistrador => 'Notário ou Registrador',
             self::ProfissionalAutonomo => 'Profissional Autônomo',
             self::SociedadeDeProfissionais => 'Sociedade de Profissionais',
-            self::NaoInformadoIdentificado7 => 'Não Informado Identificado 7',
-            self::NaoInformadoIdentificado8 => 'Não Informado Identificado 8',
-            self::NaoInformadoIdentificado9 => 'Não Informado Identificado 9',
-            self::NaoInformadoIdentificado10 => 'Não Informado Identificado 10',
+            self::Outros => 'Outros',
         };
     }
 

--- a/src/Enums/TipoDeducaoReducao.php
+++ b/src/Enums/TipoDeducaoReducao.php
@@ -5,29 +5,59 @@ namespace Nfse\Enums;
 /**
  * Tipo de dedução/redução
  *
- * Baseado no schema: TSTpDedRed
+ * Baseado no schema: TSIdeDedRed
  */
 enum TipoDeducaoReducao: string
 {
     /**
+     * Alimentação e bebidas/frigobar
+     */
+    case AlimentacaoBebidas = '1';
+
+    /**
      * Materiais
      */
-    case Materiais = '1';
+    case Materiais = '2';
 
     /**
-     * Subempreitada
+     * Produção Externa
      */
-    case Subempreitada = '2';
+    case ProducaoExterna = '3';
 
     /**
-     * Reembolso
+     * Reembolso de despesas
      */
-    case Reembolso = '3';
+    case ReembolsoDespesas = '4';
 
     /**
-     * Outros
+     * Repasse consorciado
      */
-    case Outros = '99';
+    case RepasseConsorciado = '5';
+
+    /**
+     * Repasse plano de saúde
+     */
+    case RepassePlanoSaude = '6';
+
+    /**
+     * Serviços
+     */
+    case Servicos = '7';
+
+    /**
+     * Subempreitada de mão de obra
+     */
+    case SubempreitadaMaoObra = '8';
+
+    /**
+     * Profissional parceiro
+     */
+    case ProfissionalParceiro = '9';
+
+    /**
+     * Outras deduções
+     */
+    case OutrasDeducoes = '99';
 
     /**
      * Get description for the enum case
@@ -35,10 +65,16 @@ enum TipoDeducaoReducao: string
     public function getDescription(): string
     {
         return match ($this) {
+            self::AlimentacaoBebidas => 'Alimentação e bebidas/frigobar',
             self::Materiais => 'Materiais',
-            self::Subempreitada => 'Subempreitada',
-            self::Reembolso => 'Reembolso',
-            self::Outros => 'Outros',
+            self::ProducaoExterna => 'Produção Externa',
+            self::ReembolsoDespesas => 'Reembolso de despesas',
+            self::RepasseConsorciado => 'Repasse consorciado',
+            self::RepassePlanoSaude => 'Repasse plano de saúde',
+            self::Servicos => 'Serviços',
+            self::SubempreitadaMaoObra => 'Subempreitada de mão de obra',
+            self::ProfissionalParceiro => 'Profissional parceiro',
+            self::OutrasDeducoes => 'Outras deduções',
         };
     }
 

--- a/src/Validator/DpsValidator.php
+++ b/src/Validator/DpsValidator.php
@@ -19,6 +19,7 @@ class DpsValidator
             return ValidationResult::failure(['InfDpsData is required.']);
         }
 
+        $this->validateVersao($dps, $errors);
         $this->validatePrestador($infDps, $errors);
         $this->validateTomador($infDps, $errors);
         $this->validateValores($infDps, $errors);
@@ -30,6 +31,22 @@ class DpsValidator
         }
 
         return ValidationResult::success();
+    }
+
+    /**
+     * TVerNFSe do schema: padrão 1.00|1.01, atributo obrigatório.
+     */
+    private function validateVersao(DpsData $dps, array &$errors): void
+    {
+        if ($dps->versao === null || $dps->versao === '') {
+            $errors[] = 'O atributo versao da DPS é obrigatório (1.00 ou 1.01).';
+
+            return;
+        }
+
+        if (! preg_match('/^1\.0[01]$/', $dps->versao)) {
+            $errors[] = 'A versão da DPS deve ser 1.00 ou 1.01 conforme o schema (TVerNFSe).';
+        }
     }
 
     private function validatePrestador(InfDpsData $infDps, array &$errors): void

--- a/src/Xml/NfseXmlParser.php
+++ b/src/Xml/NfseXmlParser.php
@@ -22,6 +22,9 @@ class NfseXmlParser
         // Remove escaped quotes if present (e.g. from JSON dumps)
         $xml = str_replace('\"', '"', $xml);
 
+        // Eventos no layout antigo usam nDFe; o layout 1.01 renomeou para nDFSe
+        $xml = str_replace(['<nDFe>', '</nDFe>'], ['<nDFSe>', '</nDFSe>'], $xml);
+
         // 2. Parse XML
         $useInternal = libxml_use_internal_errors(true);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -129,9 +129,9 @@ if (! function_exists('validarContraSchema')) {
     /**
      * Valida um XML contra os esquemas oficiais publicados em references/schemas.
      *
-     * O TSSerieDPS do pacote oficial usa uma expressão regular com lookahead, que não é
-     * aceita pela gramática de expressões do XML Schema e impede o libxml de compilar o
-     * esquema. A cópia usada aqui substitui apenas esse padrão.
+     * Os pacotes oficiais usam expressões regulares com lookahead e âncoras (^/$), que não são
+     * aceitas pela gramática de expressões do XML Schema e impedem o libxml de compilar o
+     * esquema. A cópia usada aqui substitui apenas esses padrões.
      */
     function validarContraSchema(string $xml, string $schema): bool
     {
@@ -143,7 +143,11 @@ if (! function_exists('validarContraSchema')) {
         }
 
         foreach (glob($origem.'/*.xsd') as $arquivo) {
-            $conteudo = str_replace('^(?!0{1,5}$)\d{1,5}$', '[0-9]{1,5}', file_get_contents($arquivo));
+            $conteudo = str_replace(
+                ['^(?!0{1,5}$)\d{1,5}$', '^0{0,4}\d{1,5}$'],
+                '[0-9]{1,5}',
+                file_get_contents($arquivo)
+            );
             file_put_contents($destino.'/'.basename($arquivo), $conteudo);
         }
 

--- a/tests/Unit/Enums/EnumsTest.php
+++ b/tests/Unit/Enums/EnumsTest.php
@@ -2,6 +2,7 @@
 
 namespace Nfse\Tests\Unit\Enums;
 
+use Nfse\Enums\CodigoStatus;
 use Nfse\Enums\EmitenteDPS;
 use Nfse\Enums\MovimentacaoTemporariaBens;
 use Nfse\Enums\ProcessoEmissao;
@@ -230,5 +231,16 @@ describe('TipoDeducaoReducao', function () {
             ->and(TipoDeducaoReducao::SubempreitadaMaoObra->getDescription())->toBe('Subempreitada de mão de obra')
             ->and(TipoDeducaoReducao::ProfissionalParceiro->getDescription())->toBe('Profissional parceiro')
             ->and(TipoDeducaoReducao::OutrasDeducoes->label())->toBe('Outras deduções');
+    });
+});
+
+describe('CodigoStatus', function () {
+    it('has only the values of TStat from schema 1.01', function () {
+        expect(CodigoStatus::cases())->toHaveCount(4)
+            ->and(CodigoStatus::NfseGerada->value)->toBe(100)
+            ->and(CodigoStatus::NfseDecisaoJudicial->value)->toBe(102)
+            ->and(CodigoStatus::NfseAvulsa->value)->toBe(103)
+            ->and(CodigoStatus::NfseMei->value)->toBe(107)
+            ->and(CodigoStatus::tryFrom(101))->toBeNull();
     });
 });

--- a/tests/Unit/Enums/EnumsTest.php
+++ b/tests/Unit/Enums/EnumsTest.php
@@ -6,6 +6,7 @@ use Nfse\Enums\CodigoStatus;
 use Nfse\Enums\EmitenteDPS;
 use Nfse\Enums\MovimentacaoTemporariaBens;
 use Nfse\Enums\ProcessoEmissao;
+use Nfse\Enums\RegimeEspecialTributacao;
 use Nfse\Enums\TipoAmbiente;
 use Nfse\Enums\TipoDeducaoReducao;
 
@@ -242,5 +243,23 @@ describe('CodigoStatus', function () {
             ->and(CodigoStatus::NfseAvulsa->value)->toBe(103)
             ->and(CodigoStatus::NfseMei->value)->toBe(107)
             ->and(CodigoStatus::tryFrom(101))->toBeNull();
+    });
+});
+
+describe('RegimeEspecialTributacao', function () {
+    it('has only the values of TSRegEspTrib from schema 1.01', function () {
+        expect(RegimeEspecialTributacao::cases())->toHaveCount(8)
+            ->and(RegimeEspecialTributacao::Nenhum->value)->toBe('0')
+            ->and(RegimeEspecialTributacao::AtoCooperado->value)->toBe('1')
+            ->and(RegimeEspecialTributacao::Estimativa->value)->toBe('2')
+            ->and(RegimeEspecialTributacao::MicroempresaMunicipal->value)->toBe('3')
+            ->and(RegimeEspecialTributacao::NotarioOuRegistrador->value)->toBe('4')
+            ->and(RegimeEspecialTributacao::ProfissionalAutonomo->value)->toBe('5')
+            ->and(RegimeEspecialTributacao::SociedadeDeProfissionais->value)->toBe('6')
+            ->and(RegimeEspecialTributacao::Outros->value)->toBe('9')
+            ->and(RegimeEspecialTributacao::Outros->getDescription())->toBe('Outros')
+            ->and(RegimeEspecialTributacao::tryFrom('7'))->toBeNull()
+            ->and(RegimeEspecialTributacao::tryFrom('8'))->toBeNull()
+            ->and(RegimeEspecialTributacao::tryFrom('10'))->toBeNull();
     });
 });

--- a/tests/Unit/Enums/EnumsTest.php
+++ b/tests/Unit/Enums/EnumsTest.php
@@ -6,6 +6,7 @@ use Nfse\Enums\EmitenteDPS;
 use Nfse\Enums\MovimentacaoTemporariaBens;
 use Nfse\Enums\ProcessoEmissao;
 use Nfse\Enums\TipoAmbiente;
+use Nfse\Enums\TipoDeducaoReducao;
 
 describe('TipoAmbiente', function () {
     it('has correct values', function () {
@@ -200,5 +201,34 @@ describe('MovimentacaoTemporariaBens', function () {
         expect(MovimentacaoTemporariaBens::Nenhum->label())->toBe('Nenhum')
             ->and(MovimentacaoTemporariaBens::Nao->label())->toBe('Não');
 
+    });
+});
+
+describe('TipoDeducaoReducao', function () {
+    it('has all values of TSIdeDedRed from schema 1.01', function () {
+        expect(TipoDeducaoReducao::cases())->toHaveCount(10)
+            ->and(TipoDeducaoReducao::AlimentacaoBebidas->value)->toBe('1')
+            ->and(TipoDeducaoReducao::Materiais->value)->toBe('2')
+            ->and(TipoDeducaoReducao::ProducaoExterna->value)->toBe('3')
+            ->and(TipoDeducaoReducao::ReembolsoDespesas->value)->toBe('4')
+            ->and(TipoDeducaoReducao::RepasseConsorciado->value)->toBe('5')
+            ->and(TipoDeducaoReducao::RepassePlanoSaude->value)->toBe('6')
+            ->and(TipoDeducaoReducao::Servicos->value)->toBe('7')
+            ->and(TipoDeducaoReducao::SubempreitadaMaoObra->value)->toBe('8')
+            ->and(TipoDeducaoReducao::ProfissionalParceiro->value)->toBe('9')
+            ->and(TipoDeducaoReducao::OutrasDeducoes->value)->toBe('99');
+    });
+
+    it('can create from value', function () {
+        expect(TipoDeducaoReducao::from('3'))->toBe(TipoDeducaoReducao::ProducaoExterna)
+            ->and(TipoDeducaoReducao::tryFrom('4'))->toBe(TipoDeducaoReducao::ReembolsoDespesas)
+            ->and(TipoDeducaoReducao::tryFrom('10'))->toBeNull();
+    });
+
+    it('returns correct descriptions', function () {
+        expect(TipoDeducaoReducao::AlimentacaoBebidas->getDescription())->toBe('Alimentação e bebidas/frigobar')
+            ->and(TipoDeducaoReducao::SubempreitadaMaoObra->getDescription())->toBe('Subempreitada de mão de obra')
+            ->and(TipoDeducaoReducao::ProfissionalParceiro->getDescription())->toBe('Profissional parceiro')
+            ->and(TipoDeducaoReducao::OutrasDeducoes->label())->toBe('Outras deduções');
     });
 });

--- a/tests/Unit/Validator/DpsValidatorIbscbsTest.php
+++ b/tests/Unit/Validator/DpsValidatorIbscbsTest.php
@@ -35,7 +35,10 @@ function validarDpsComIbscbs(array $ibscbs, array $sobrescritas = []): array
         'IBSCBS' => $ibscbs,
     ], $sobrescritas);
 
-    return (new DpsValidator)->validate(new DpsData(['infDPS' => $infDps]))->errors;
+    return (new DpsValidator)->validate(new DpsData([
+        '@attributes' => ['versao' => '1.01'],
+        'infDPS' => $infDps,
+    ]))->errors;
 }
 
 function ibscbsValido(array $sobrescritas = []): array

--- a/tests/Unit/Validator/DpsValidatorTest.php
+++ b/tests/Unit/Validator/DpsValidatorTest.php
@@ -491,3 +491,54 @@ it('validates DPS with construction service and obra information', function () {
     expect($result->isValid)->toBeTrue();
     expect($result->errors)->toBeEmpty();
 });
+
+it('rejects a DPS with a missing versao attribute', function () {
+    $dps = new DpsData([
+        'infDPS' => [
+            'tpAmb' => 2,
+            'dhEmi' => '2023-10-27T10:00:00',
+            'verAplic' => '1.0',
+            'serie' => '1',
+            'nDPS' => '1',
+            'dCompet' => '2023-10-27',
+            'tpEmit' => 1,
+            'cLocEmi' => '1234567',
+            'prest' => [
+                'CNPJ' => '12345678000199',
+                'IM' => '12345',
+                'xNome' => 'Prestador Teste',
+            ],
+        ],
+    ]);
+
+    $result = (new DpsValidator)->validate($dps);
+
+    expect($result->isValid)->toBeFalse()
+        ->and($result->errors)->toContain('O atributo versao da DPS é obrigatório (1.00 ou 1.01).');
+});
+
+it('rejects a DPS with an invalid versao attribute', function () {
+    $dps = new DpsData([
+        '@attributes' => ['versao' => '1.0'],
+        'infDPS' => [
+            'tpAmb' => 2,
+            'dhEmi' => '2023-10-27T10:00:00',
+            'verAplic' => '1.0',
+            'serie' => '1',
+            'nDPS' => '1',
+            'dCompet' => '2023-10-27',
+            'tpEmit' => 1,
+            'cLocEmi' => '1234567',
+            'prest' => [
+                'CNPJ' => '12345678000199',
+                'IM' => '12345',
+                'xNome' => 'Prestador Teste',
+            ],
+        ],
+    ]);
+
+    $result = (new DpsValidator)->validate($dps);
+
+    expect($result->isValid)->toBeFalse()
+        ->and($result->errors)->toContain('A versão da DPS deve ser 1.00 ou 1.01 conforme o schema (TVerNFSe).');
+});

--- a/tests/Unit/Xml/NfseXmlParserRealXmlTest.php
+++ b/tests/Unit/Xml/NfseXmlParserRealXmlTest.php
@@ -39,6 +39,7 @@ it('parses another world xml 3', function () {
         ->and($nfseData->infEvento)->toBeInstanceOf(\Nfse\Dto\Nfse\InfEventoData::class)
         ->and($nfseData->infEvento->versaoAplicativo)->toBe('EmissorWeb_1.3.0.0')
         ->and($nfseData->infEvento->ambiente)->toBe(2)
+        ->and($nfseData->infEvento->numeroDfse)->toBe('0')
         ->and($nfseData->infEvento->pedRegEvento->infPedReg->e101101->descricao)->toBe('Cancelamento de NFS-e');
 });
 
@@ -65,4 +66,14 @@ it('parses another world xml 5', function () {
         ->and($nfseData->infEvento->versaoAplicativo)->toBe('EmissorWeb_1.3.0.0')
         ->and($nfseData->infEvento->ambiente)->toBe(2)
         ->and($nfseData->infEvento->pedRegEvento->infPedReg->e101101->descricao)->toBe('Cancelamento de NFS-e');
+});
+
+it('parses evento with nDFSe from layout 1.01', function () {
+    $xml = '<?xml version="1.0" encoding="utf-8"?><evento versao="1.01" xmlns="http://www.sped.fazenda.gov.br/nfse"><infEvento Id="EVT23044002257302627000114000000000000524107932661061101101001"><verAplic>EmissorWeb_1.3.0.0</verAplic><ambGer>2</ambGer><nSeqEvento>1</nSeqEvento><dhProc>2026-08-21T10:00:00-03:00</dhProc><nDFSe>42</nDFSe><pedRegEvento versao="1.01" xmlns="http://www.sped.fazenda.gov.br/nfse"><infPedReg Id="PRE23044002257302627000114000000000000524107932661061101101001"><tpAmb>1</tpAmb><verAplic>EmissorWeb_1.3.0.0</verAplic><dhEvento>2026-08-21T10:00:00-03:00</dhEvento><CNPJAutor>57302627000114</CNPJAutor><chNFSe>23044002257302627000114000000000000524107932661061</chNFSe><nPedRegEvento>1</nPedRegEvento><e101101><xDesc>Cancelamento de NFS-e</xDesc><cMotivo>1</cMotivo><xMotivo>Teste</xMotivo></e101101></infPedReg></pedRegEvento></infEvento></evento>';
+
+    $parser = new NfseXmlParser;
+    $nfseData = $parser->parse($xml);
+
+    expect($nfseData->infEvento->numeroDfse)->toBe('42')
+        ->and($nfseData->infEvento->numeroSequencialEvento)->toBe(1);
 });


### PR DESCRIPTION
# Atualiza schemas NFS-e para o layout 1.01 (pacote de 09/02/2026) e alinha o código

## Contexto

Os schemas XSD em `references/schemas/` estavam desatualizados. Este PR os substitui pelo pacote oficial mais recente, publicado em [documentação técnica do NFS-e Nacional](https://www.gov.br/nfse/pt-br/biblioteca/documentacao-tecnica/documentacao-atual) (data de referência: **09/02/2026**), e ajusta o código nos pontos em que ainda seguia o layout antigo.

Gosto de conferir o schema como referência enquanto monto a DPS, e a falta de algumas informações que já estavam atualizadas no site oficial me deixou confuso — daí a motivação deste PR: deixar o repositório fiel ao layout vigente.

## O que o novo layout mudou (schemas)

- Remove o grupo de pedágio (`explRod`/`TCExploracaoRodoviaria`) de `tiposComplexos`
- Remove o status `101` (NFS-e de Substituição Gerada) e os códigos de evento `e907202`/`e967203` de `tiposSimples`
- Adiciona os valores 49–99 ao CST PIS/COFINS e 0–9 à retenção PIS/COFINS/CSLL
- Expande `TSIdeDedRed` para 10 valores e torna `cNBS` opcional
- Renomeia `nDFe` para `nDFSe` e torna `verAplic` obrigatório em `tiposEventos`
- Move `TVerCNC` para `tiposCnc`; versão dos documentos passa a aceitar `1.00|1.01`
- Normaliza fins de linha CRLF → LF

## Alinhamento do código

| Mudança | Commit |
|---|---|
| Schemas atualizados | `f80ff64` |
| Helper de teste cobre o novo padrão de regex do schema | `3ae2259` |
| `TipoDeducaoReducao` com os 10 valores do novo `TSIdeDedRed` | `b02c7e3` |
| Parse de eventos: `nDFe` → `nDFSe`, com compatibilidade para respostas legadas | `cee052a` |
| `CodigoStatus`: remoção do status 101 | `42e6868` |
| `RegimeEspecialTributacao`: remove valores inválidos (7, 8, 10) e corrige `9 = Outros` | `63aff05` |
| `InfPedRegData`: remove eventos `e907202`/`e967203` | `43f646e` |
| `DpsValidator`: exige `versao` da DPS como `1.00` ou `1.01` (`TVerNFSe`) | `e1d7250` |

## Já estava em conformidade com o novo schema

Vale ressaltar que boa parte do código **já seguia o layout novo** antes deste PR, sem precisar de mudanças:

- `TipoRetencaoPisCofins` já tinha os 10 valores (0–9)
- `CstPisCofins` já incluía os códigos 49–99 com o 07 corrigido ("Operação Isenta")
- O `EventosXmlBuilder` já gerava o Id do pedido de registro de evento no formato `TSIdPedRegEvt` (`PRE` + 56 dígitos)
- O grupo de pedágio (removido no layout novo) nunca foi implementado — correto
- `verAplic` sempre foi emitido no pedido de registro de evento, agora obrigatório no schema
- `nDFSe` já era usado no contexto da NFS-e (`NfseXmlBuilder`/`InfNfseData`)

## Testes

- Suíte completa: **220 testes passando, 821 asserções** (2 pulados por ambiente)
- Adicionada cobertura direta para `TipoDeducaoReducao`, `CodigoStatus` e `RegimeEspecialTributacao`, que não tinham testes
- Verificado de ponta a ponta que os 10 valores de `tpDedRed` produzem XML válido contra o schema novo
- phpstan: mesmos 10 erros preexistentes nos clients HTTP (sem regressão)